### PR TITLE
build: limit snap builds to amd64/arm64

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -12,6 +12,11 @@ description: |
   (**not** by Amazon/AWS)
 confinement: strict
 license: GPL-3.0
+architectures:
+  - build-on: [amd64]
+    run-on: [amd64]
+  - build-on: [arm64]
+    run-on: [arm64]
 
 plugs:
   dot-aws-config:


### PR DESCRIPTION
snapcraft, by default builds on all architectures. riscv64 in particular will fail. Limiting this package to only amd64/arm64 will cover most users while limiting test resource usage.