### PR TITLE
fix: invalid snapcraft architectures structure

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -14,9 +14,7 @@ confinement: strict
 license: GPL-3.0
 architectures:
   - build-on: [amd64]
-    run-on: [amd64]
   - build-on: [arm64]
-    run-on: [arm64]
 
 plugs:
   dot-aws-config:


### PR DESCRIPTION
previous architectures format was based on core20. core22 changes run-on to build-for, but it is redundant if the value is identical to build-on and can be ommitted.