### PR TITLE
Single command public offer

### DIFF
--- a/awsmp/_driver.py
+++ b/awsmp/_driver.py
@@ -27,31 +27,26 @@ class AmiProduct:
     def create():
         changeset = changesets.get_ami_listing_creation_changesets()
         changeset_name = "Create new AMI Product"
-        changeset_stringified = changesets.stringify_changeset_details(changeset)
 
-        return get_response(changeset_stringified, changeset_name)
+        return get_response(changeset, changeset_name)
 
     def update_legal_terms(self, eula_url: str) -> ChangeSetReturnType:
         changeset = changesets.get_ami_listing_update_legal_terms_changesets(self.offer_id, eula_url)
         changeset_name = f"Product {self.product_id} legal terms update"
-        changeset_stringified = changesets.stringify_changeset_details(changeset)
 
-        return get_response(changeset_stringified, changeset_name)
+        return get_response(changeset, changeset_name)
 
     def update_support_terms(self, refund_policy: str) -> ChangeSetReturnType:
         changeset = changesets.get_ami_listing_update_support_terms_changesets(self.offer_id, refund_policy)
         changeset_name = f"Product {self.product_id} support terms update"
-        changeset_stringified = changesets.stringify_changeset_details(changeset)
 
-        return get_response(changeset_stringified, changeset_name)
+        return get_response(changeset, changeset_name)
 
     def update_description(self, desc: Dict) -> ChangeSetReturnType:
         changeset = changesets.get_ami_listing_update_description_changesets(self.product_id, desc)
         changeset_name = f"Product {self.product_id} description update"
 
-        changeset_stringified = changesets.stringify_changeset_details(changeset)
-
-        return get_response(changeset_stringified, changeset_name)
+        return get_response(changeset, changeset_name)
 
     def update_instance_types(
         self, instance_types: IO, dimension_unit: Literal["Hrs", "Units"], free: bool
@@ -109,11 +104,11 @@ def get_client(service_name="marketplace-catalog", region_name="us-east-1"):
     return boto3.client(service_name, region_name=region_name)
 
 
-def get_response(changeset_stringified: ChangeSetType, changeset_name: str) -> ChangeSetReturnType:
+def get_response(changeset: List[ChangeSetType], changeset_name: str) -> ChangeSetReturnType:
     """
     Request to AWS and get response of either success of failure
 
-    :param ChangeSetType changeset_stringified: string type of changeset
+    :param List[ChangeSetType] changeset: list of changesets
     :param str changeset_name: name of changeset
     :return: changeset with type, entity, details etc.
     :rtype: ChangeSetReturnType
@@ -121,7 +116,7 @@ def get_response(changeset_stringified: ChangeSetType, changeset_name: str) -> C
     try:
         response = get_client().start_change_set(
             Catalog="AWSMarketplace",
-            ChangeSet=changeset_stringified,
+            ChangeSet=changeset,
             ChangeSetName=changeset_name,
         )
     except ClientError as e:
@@ -203,7 +198,7 @@ def get_entity_versions(entity_id: str) -> List[dict[str, str]]:
 
 
 def _get_ratecard_info(changeset: Dict, idx: int, instance_types: List[str]) -> List[Dict]:
-    ratecard = changeset[3]["Details"]["Terms"][idx]["RateCards"][0]["RateCard"]
+    ratecard = changeset[3]["DetailsDocument"]["Terms"][idx]["RateCards"][0]["RateCard"]
     return [r for r in ratecard if r["DimensionKey"] in instance_types]
 
 
@@ -219,7 +214,7 @@ def _get_existing_instance_types(product_id: str):
 def _filter_instance_types(product_id: str, changeset):
     existing_instance_types = _get_existing_instance_types(product_id)
     pricing_instance_types = {
-        t["DimensionKey"] for t in changeset[3]["Details"]["Terms"][0]["RateCards"][0]["RateCard"]
+        t["DimensionKey"] for t in changeset[3]["DetailsDocument"]["Terms"][0]["RateCards"][0]["RateCard"]
     }
 
     if missing_instance_types := existing_instance_types.difference(pricing_instance_types):
@@ -229,7 +224,7 @@ def _filter_instance_types(product_id: str, changeset):
 
     # idx 0 is hourly pricing, and 1 is annual
     for idx in {0, 1}:
-        changeset[3]["Details"]["Terms"][idx]["RateCards"][0]["RateCard"] = _get_ratecard_info(
+        changeset[3]["DetailsDocument"]["Terms"][idx]["RateCards"][0]["RateCard"] = _get_ratecard_info(
             changeset, idx, intersect
         )
     return changeset
@@ -258,13 +253,12 @@ def offer_create(
     )
 
     changeset_list = _filter_instance_types(product_id, changeset_list)
-    changeset_stringified = changesets.stringify_changeset_details(changeset_list)
 
     client = get_client()
 
     changeset_name = f'{f"create private offer for {product_id}: {offer_name}"[:95]}...'.replace(",", "_")
 
-    return get_response(changeset_stringified, changeset_name)
+    return get_response(changeset_list, changeset_name)
 
 
 def create_offer_name(product_id: str, buyer_accounts: List[str], with_support: bool, customer_name: str) -> str:

--- a/awsmp/_driver.py
+++ b/awsmp/_driver.py
@@ -1,6 +1,6 @@
 import csv
 import logging
-from typing import IO, Dict, List, Literal, Optional
+from typing import IO, Any, Dict, List, Literal, Optional
 
 import boto3
 from botocore.exceptions import ClientError
@@ -69,30 +69,37 @@ class AmiProduct:
             self.product_id, self.offer_id, instance_type_pricing, dimension_unit, new_instance_types, free
         )
         changeset_name = f"Product {self.product_id} instance type update"
-        changeset_stringified = changesets.stringify_changeset_details(changeset)
 
-        return get_response(changeset_stringified, changeset_name)
+        return get_response(changeset, changeset_name)
 
     def update_regions(self, region_config: Dict) -> ChangeSetReturnType:
         changeset = changesets.get_ami_listing_update_region_changesets(self.product_id, region_config)
         changeset_name = f"Product {self.product_id} region update"
-        changeset_stringified = changesets.stringify_changeset_details(changeset)
 
-        return get_response(changeset_stringified, changeset_name)
+        return get_response(changeset, changeset_name)
 
     def update_version(self, version_config: Dict) -> ChangeSetReturnType:
         changeset = changesets.get_ami_listing_update_version_changesets(self.product_id, version_config)
         changeset_name = f"Product {self.product_id} version update"
-        changeset_stringified = changesets.stringify_changeset_details(changeset)
 
-        return get_response(changeset_stringified, changeset_name)
+        return get_response(changeset, changeset_name)
 
     def release(self) -> ChangeSetReturnType:
         changeset = changesets.get_ami_release_changesets(self.product_id, self.offer_id)
         changeset_name = f"Product {self.product_id} publish as limited"
-        changeset_stringified = changesets.stringify_changeset_details(changeset)
 
-        return get_response(changeset_stringified, changeset_name)
+        return get_response(changeset, changeset_name)
+
+    def update(self, configs: dict[str, Any]) -> ChangeSetReturnType:
+        """
+        Update AMI product details (Description, Region)
+        """
+        changeset = changesets.get_ami_listing_update_changesets(
+            self.product_id, configs["description"], configs["region"]
+        )
+        changeset_name = f"Product {self.product_id} update product details"
+
+        return get_response(changeset, changeset_name)
 
     def _get_product_title(self):
         return get_entity_details(self.product_id)["Description"]["ProductTitle"]

--- a/awsmp/changesets.py
+++ b/awsmp/changesets.py
@@ -18,7 +18,7 @@ def _changeset_create_offer(product_id: str, offer_name: str) -> ChangeSetType:
         "ChangeType": "CreateOffer",
         "ChangeName": "CreateOfferChange",
         "Entity": {"Type": "Offer@1.0"},
-        "Details": {
+        "DetailsDocument": {
             "ProductId": product_id,
         },
     }
@@ -29,7 +29,7 @@ def _changeset_create_ami_product() -> ChangeSetType:
         "ChangeType": "CreateProduct",
         "ChangeName": "CreateProductChange",
         "Entity": {"Type": "AmiProduct@1.0"},
-        "Details": {},
+        "DetailsDocument": {},
     }
 
 
@@ -40,7 +40,7 @@ def _changeset_update_information(
     return {
         "ChangeType": "UpdateInformation",
         "Entity": {"Type": "Offer@1.0", "Identifier": offer_id},
-        "Details": {
+        "DetailsDocument": {
             "Name": offer_name,
             "Description": "testing automatic offer creation",
         },
@@ -51,7 +51,7 @@ def _changeset_update_targeting(buyer_accounts: List[str]) -> ChangeSetType:
     return {
         "ChangeType": "UpdateTargeting",
         "Entity": {"Type": "Offer@1.0", "Identifier": "$CreateOfferChange.Entity.Identifier"},
-        "Details": {"PositiveTargeting": {"BuyerAccounts": buyer_accounts}},
+        "DetailsDocument": {"PositiveTargeting": {"BuyerAccounts": buyer_accounts}},
     }
 
 
@@ -120,7 +120,7 @@ def _changeset_update_pricing_terms(
     return {
         "ChangeType": "UpdatePricingTerms",
         "Entity": {"Type": "Offer@1.0", "Identifier": offer_id},
-        "Details": {"PricingModel": "Usage", "Terms": terms},
+        "DetailsDocument": {"PricingModel": "Usage", "Terms": terms},
     }
 
 
@@ -132,7 +132,7 @@ def _changeset_update_availability(days_from_today: int) -> ChangeSetType:
             "Type": "Offer@1.0",
             "Identifier": "$CreateOfferChange.Entity.Identifier",
         },
-        "Details": {"AvailabilityEndDate": end.strftime("%Y-%m-%d")},
+        "DetailsDocument": {"AvailabilityEndDate": end.strftime("%Y-%m-%d")},
     }
 
 
@@ -147,7 +147,7 @@ def _changeset_update_legal_terms(offer_id: Optional[str] = None, eula_url: Opti
     return {
         "ChangeType": "UpdateLegalTerms",
         "Entity": {"Type": "Offer@1.0", "Identifier": offer_id},
-        "Details": {
+        "DetailsDocument": {
             "Terms": [
                 {
                     "Type": "LegalTerm",
@@ -162,7 +162,7 @@ def _changeset_update_validity_terms(days: int) -> ChangeSetType:
     return {
         "ChangeType": "UpdateValidityTerms",
         "Entity": {"Type": "Offer@1.0", "Identifier": "$CreateOfferChange.Entity.Identifier"},
-        "Details": {"Terms": [{"Type": "ValidityTerm", "AgreementDuration": f"P{days}D"}]},
+        "DetailsDocument": {"Terms": [{"Type": "ValidityTerm", "AgreementDuration": f"P{days}D"}]},
     }
 
 
@@ -175,7 +175,7 @@ def _changeset_release_offer(offer_id: Optional[str] = None) -> ChangeSetType:
             "Type": "Offer@1.0",
             "Identifier": offer_id,
         },
-        "Details": {},
+        "DetailsDocument": {},
     }
 
 
@@ -188,7 +188,7 @@ def _changeset_update_support_terms(refund_policy: str, offer_id: Optional[str] 
             "Type": "Offer@1.0",
             "Identifier": offer_id,
         },
-        "Details": {
+        "DetailsDocument": {
             "Terms": [
                 {
                     "Type": "SupportTerm",
@@ -210,7 +210,7 @@ def _changeset_update_ami_product_description(product_id: str, desc: Dict) -> Ch
             "Type": "AmiProduct@1.0",
             "Identifier": product_id,
         },
-        "Details": {
+        "DetailsDocument": {
             "ProductTitle": desc["product_title"],
             "LogoUrl": desc["logourl"],
             "ShortDescription": desc["short_description"],
@@ -234,7 +234,7 @@ def _changeset_update_ami_product_instance_type(product_id: str, new_instance_ty
             "Type": "AmiProduct@1.0",
             "Identifier": product_id,
         },
-        "Details": {"InstanceTypes": new_instance_types},
+        "DetailsDocument": {"InstanceTypes": new_instance_types},
     }
 
 
@@ -249,7 +249,7 @@ def _changeset_update_ami_product_region(product_id: str, region_config: Dict) -
             "Type": "AmiProduct@1.0",
             "Identifier": product_id,
         },
-        "Details": {"Regions": regions.commercial_regions},
+        "DetailsDocument": {"Regions": regions.commercial_regions},
     }
 
 
@@ -262,7 +262,7 @@ def _changeset_update_ami_product_future_region(product_id: str, region_config: 
             "Type": "AmiProduct@1.0",
             "Identifier": product_id,
         },
-        "Details": {"FutureRegionSupport": {"SupportedRegions": region.future_region_supported()}},
+        "DetailsDocument": {"FutureRegionSupport": {"SupportedRegions": region.future_region_supported()}},
     }
 
 
@@ -292,7 +292,7 @@ def _changeset_update_ami_product_dimension(
             "Type": "AmiProduct@1.0",
             "Identifier": product_id,
         },
-        "Details": dimension_changeset,
+        "DetailsDocument": dimension_changeset,
     }
 
 
@@ -305,7 +305,7 @@ def _changeset_update_ami_product_version(product_id: str, version_config: Dict)
             "Type": "AmiProduct@1.0",
             "Identifier": product_id,
         },
-        "Details": {
+        "DetailsDocument": {
             "Version": {
                 "VersionTitle": version.version_title,
                 "ReleaseNotes": version.release_notes,
@@ -347,20 +347,8 @@ def _changeset_release_ami_product(product_id: str) -> ChangeSetType:
             "Type": "AmiProduct@1.0",
             "Identifier": product_id,
         },
-        "Details": {},
+        "DetailsDocument": {},
     }
-
-
-def stringify_changeset_details(changesets: List[ChangeSetType]):
-    for change_type in changesets:
-        # Only stringify details section if it is not empty
-        if change_type["Details"] != "{}":
-            string_details = json.dumps(change_type["Details"])
-            change_type["Details"] = string_details
-        else:
-            pass
-
-    return changesets
 
 
 def get_changesets(

--- a/awsmp/changesets.py
+++ b/awsmp/changesets.py
@@ -443,3 +443,11 @@ def get_ami_release_changesets(product_id: str, offer_id: str) -> List[ChangeSet
         _changeset_update_information(f"Product id {product_id} public offer", offer_id),
         _changeset_release_offer(offer_id=offer_id),
     ]
+
+
+def get_ami_listing_update_changesets(product_id: str, description: dict, region_config: dict) -> List[ChangeSetType]:
+    return [
+        _changeset_update_ami_product_description(product_id, description),
+        _changeset_update_ami_product_region(product_id, region_config),
+        _changeset_update_ami_product_future_region(product_id, region_config),
+    ]

--- a/awsmp/cli.py
+++ b/awsmp/cli.py
@@ -387,6 +387,23 @@ def ami_product_release(product_id):
     print(f'https://aws.amazon.com/marketplace/management/requests/{response["ChangeSetId"]}')
 
 
+@public_offer.command("update")
+@click.option("--product-id", required=True, prompt=True)
+@click.option("--config", type=click.File("r"), required=True, prompt=True)
+def ami_product_update(product_id, config):
+    """
+    Update AMI product details (description, region) with single call
+    """
+
+    # Load yaml file
+    configs = _load_configuration(config, ["description", "region"])
+
+    product = _driver.AmiProduct(product_id=product_id)
+    response = product.update(configs)
+    print(f'ChangeSet created (ID: {response["ChangeSetId"]})')
+    print(f'https://aws.amazon.com/marketplace/management/requests/{response["ChangeSetId"]}')
+
+
 def _load_configuration(config_path: TextIO, required_fields: List[str]) -> Dict:
     """
     Check if keys exist in config file before creating changeset and return config dict

--- a/awsmp/cli.py
+++ b/awsmp/cli.py
@@ -203,7 +203,7 @@ def offer_pricing_template(offer_id, pricing, free):
     """
     client = _driver.get_client()
     e = client.describe_entity(Catalog="AWSMarketplace", EntityId=offer_id)
-    details = json.loads(e["Details"])
+    details = e["DetailsDocument"]
 
     prices_hourly = {}
     prices_annual = {}

--- a/awsmp/types.py
+++ b/awsmp/types.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Literal, TypedDict, Union
+from typing import Any, Dict, List, Literal, TypedDict
 
 from typing_extensions import NotRequired
 
@@ -15,7 +15,7 @@ class ChangeSetType(TypedDict):
     ChangeType: str
     ChangeName: NotRequired[str]
     Entity: Dict[str, str]
-    Details: Union[Dict[str, Any], str]
+    DetailsDocument: Dict[str, Any]
     ChangeSetId: NotRequired[str]
 
 

--- a/docs/public-offer/index.rst
+++ b/docs/public-offer/index.rst
@@ -234,4 +234,16 @@ To publish drafted AMI listing to :guilabel:`Limited` state, product ID and publ
 
 
 
+Update AMI product listing details
+----------------------------------
+
+To update AMI product listing with multiple requests for product details (Description and Region Availability), run the command below, passing the product ID and product configuration file:
+
+.. code-block:: sh
+
+   awsmp public-offer update \
+      --product-id prod-fwu3xsqup23cs
+      --config listing_configuration.yaml
+
+
 .. _`AWS marketplace management portal`: https://aws.amazon.com/marketplace/management/

--- a/tests/local_config/test_config_3.yaml
+++ b/tests/local_config/test_config_3.yaml
@@ -1,0 +1,55 @@
+description:
+  product_title: "test_prod"
+  logourl: "https://test-logourl.pdf"
+  video_urls:
+    - "https://test-video"
+  short_description: "test_short_description\nshort_description"
+  long_description: |
+    test_long_description
+
+    very_long
+  highlights:
+    - "test_highlight_1"
+    - "test_highlight_2"
+  search_keywords:
+    - "test_keyword_1"
+    - "test_keyword_2"
+  categories:
+    - "Migration"
+    - "Testing"
+  support_description: |
+    test_support_description
+
+    with new lines
+
+  support_resources:
+    - "test_support_resource"
+  additional_resources:
+    - test-link: "https://test-url"
+    - test-link2: "https://test-url2"
+  sku: "test"
+region:
+  commercial_regions:
+    - us-east-1
+  future_region_support: False
+version:
+  version_title: "test_version_title"
+  release_notes: |
+    test_release_notes
+  ami_id: ami-test3
+  access_role_arn: arn:aws:iam::test
+  os_user_name: test_os_user_name
+  os_system_version: test_os_system_version
+  os_system_name: test_os
+  scanning_port: 22
+  usage_instructions: |
+    test_usage_instructions
+  recommended_instance_type: m5.large
+  ip_protocol: tcp
+  ip_ranges:
+    - "0.0.0.0/0"
+  from_port: 22
+  to_port: 22
+refund_policy: |
+  test_refund_policy_term
+eula_url: "test_eula_url"

--- a/tests/local_config/test_config_4.yaml
+++ b/tests/local_config/test_config_4.yaml
@@ -1,0 +1,60 @@
+description:
+  product_title: "test_prod_id"
+  logourl: "https://test-logourl.svg"
+  video_urls: []
+  short_description: "test_long_description and another short description and short description"
+  long_description: |
+    test_long_description
+    new_line
+    another_new_line
+  highlights:
+    - "test_highlight_1"
+    - "test_highlight_2"
+    - "test_highlight_3"
+  search_keywords:
+    - "test_keyword_1"
+    - "test_keyword_2"
+    - "test_keyword_3"
+    - "test_keyword_4"
+    - "test_keyword_5"
+    - "test_keyword_6"
+  categories:
+    - "Migration"
+    - "Testing"
+    - "Blockchain"
+  support_description: |
+    test_support_description
+    with multiple line
+    lines
+  support_resources:
+    - "test_support_resource"
+  additional_resources:
+    - test-link1: "https://test-url1"
+    - test-link2: "https://test-url2"
+    - test-link3: "https://test-url3"
+  sku: "test"
+region:
+  commercial_regions:
+    - us-east-2
+  future_region_support: True
+version:
+  version_title: "test_version_title"
+  release_notes: |
+    test_release_notes
+  ami_id: ami-test4
+  access_role_arn: arn:aws:iam::test
+  os_user_name: test_os_user_name
+  os_system_version: test_os_system_version
+  os_system_name: test_os
+  scanning_port: 22
+  usage_instructions: |
+    test_usage_instructions
+  recommended_instance_type: m5.large
+  ip_protocol: tcp
+  ip_ranges:
+    - "0.0.0.0/0"
+  from_port: 22
+  to_port: 22
+refund_policy: |
+  test_refund_policy_term
+eula_url: "test_eula_url"

--- a/tests/test_changesets.py
+++ b/tests/test_changesets.py
@@ -1,6 +1,11 @@
-import pytest
+from typing import Any, List
+from unittest.mock import patch
 
-from awsmp import changesets
+import pytest
+import yaml
+from pydantic import ValidationError
+
+from awsmp import changesets, types
 
 
 @pytest.mark.parametrize(
@@ -10,3 +15,327 @@ from awsmp import changesets
 def test_changeset_update_legal_terms_eula_options(eula_url, expected):
     result = changesets._changeset_update_legal_terms(eula_url=eula_url)
     result["Details"]["Terms"][0] == expected  # type: ignore
+
+
+@pytest.mark.parametrize(
+    "file_path, expected_desc",
+    [
+        ("./tests/test_config.yaml", "test"),
+        ("./tests/local_config/test_config_3.yaml", "test_prod"),
+        ("./tests/local_config/test_config_4.yaml", "test_prod_id"),
+    ],
+)
+@patch("awsmp.models.boto3")
+def test_get_ami_product_update_changeset_description_title(mock_boto3, file_path, expected_desc):
+    mock_boto3.client.return_value.describe_regions.return_value = {
+        "Regions": [
+            {"Endpoint": "ec2.us-east-1.amazonaws.com", "RegionName": "us-east-1", "OptInStatus": "opted-in"},
+            {"Endpoint": "ec2.us-east-2.amazonaws.com", "RegionName": "us-east-2", "OptInStatus": "opted-in"},
+        ]
+    }
+    with open(file_path, "r") as f:
+        config = yaml.safe_load(f)
+    res: List[types.ChangeSetType] = changesets.get_ami_listing_update_changesets(
+        "test-id", config["description"], config["region"]
+    )
+    assert res[0]["DetailsDocument"]["ProductTitle"] == expected_desc
+
+
+@pytest.mark.parametrize(
+    "file_path, expected_desc",
+    [
+        ("./tests/test_config.yaml", "test_long_description"),
+        ("./tests/local_config/test_config_3.yaml", "test_long_description\n\nvery_long"),
+        ("./tests/local_config/test_config_4.yaml", "test_long_description\nnew_line\nanother_new_line"),
+    ],
+)
+@patch("awsmp.models.boto3")
+def test_get_ami_product_update_changeset_description_long_desc(mock_boto3, file_path, expected_desc):
+    mock_boto3.client.return_value.describe_regions.return_value = {
+        "Regions": [
+            {"Endpoint": "ec2.us-east-1.amazonaws.com", "RegionName": "us-east-1", "OptInStatus": "opted-in"},
+            {"Endpoint": "ec2.us-east-2.amazonaws.com", "RegionName": "us-east-2", "OptInStatus": "opted-in"},
+        ]
+    }
+    with open(file_path, "r") as f:
+        config = yaml.safe_load(f)
+    res: List[types.ChangeSetType] = changesets.get_ami_listing_update_changesets(
+        "test-id", config["description"], config["region"]
+    )
+    assert res[0]["DetailsDocument"]["LongDescription"] == expected_desc
+
+
+@pytest.mark.parametrize(
+    "file_path, expected_desc",
+    [
+        ("./tests/test_config.yaml", "test_short_description"),
+        ("./tests/local_config/test_config_3.yaml", "test_short_description\nshort_description"),
+        (
+            "./tests/local_config/test_config_4.yaml",
+            "test_long_description and another short description and short description",
+        ),
+    ],
+)
+@patch("awsmp.models.boto3")
+def test_get_ami_product_update_changeset_description_short_desc(mock_boto3, file_path, expected_desc):
+    mock_boto3.client.return_value.describe_regions.return_value = {
+        "Regions": [
+            {"Endpoint": "ec2.us-east-1.amazonaws.com", "RegionName": "us-east-1", "OptInStatus": "opted-in"},
+            {"Endpoint": "ec2.us-east-2.amazonaws.com", "RegionName": "us-east-2", "OptInStatus": "opted-in"},
+        ]
+    }
+    with open(file_path, "r") as f:
+        config = yaml.safe_load(f)
+    res: List[types.ChangeSetType] = changesets.get_ami_listing_update_changesets(
+        "test-id", config["description"], config["region"]
+    )
+    assert res[0]["DetailsDocument"]["ShortDescription"] == expected_desc
+
+
+@pytest.mark.parametrize(
+    "file_path, expected_desc",
+    [
+        ("./tests/test_config.yaml", "https://test-logourl"),
+        ("./tests/local_config/test_config_3.yaml", "https://test-logourl.pdf"),
+        ("./tests/local_config/test_config_4.yaml", "https://test-logourl.svg"),
+    ],
+)
+@patch("awsmp.models.boto3")
+def test_get_ami_product_update_changeset_description_logourl(mock_boto3, file_path, expected_desc):
+    mock_boto3.client.return_value.describe_regions.return_value = {
+        "Regions": [
+            {"Endpoint": "ec2.us-east-1.amazonaws.com", "RegionName": "us-east-1", "OptInStatus": "opted-in"},
+            {"Endpoint": "ec2.us-east-2.amazonaws.com", "RegionName": "us-east-2", "OptInStatus": "opted-in"},
+        ]
+    }
+    with open(file_path, "r") as f:
+        config = yaml.safe_load(f)
+    res: List[types.ChangeSetType] = changesets.get_ami_listing_update_changesets(
+        "test-id", config["description"], config["region"]
+    )
+    assert res[0]["DetailsDocument"]["LogoUrl"] == expected_desc
+
+
+@pytest.mark.parametrize(
+    "file_path, expected_desc",
+    [
+        ("./tests/test_config.yaml", ["test_highlight_1"]),
+        ("./tests/local_config/test_config_3.yaml", ["test_highlight_1", "test_highlight_2"]),
+        ("./tests/local_config/test_config_4.yaml", ["test_highlight_1", "test_highlight_2", "test_highlight_3"]),
+    ],
+)
+@patch("awsmp.models.boto3")
+def test_get_ami_product_update_changeset_description_highlights(mock_boto3, file_path, expected_desc):
+    mock_boto3.client.return_value.describe_regions.return_value = {
+        "Regions": [
+            {"Endpoint": "ec2.us-east-1.amazonaws.com", "RegionName": "us-east-1", "OptInStatus": "opted-in"},
+            {"Endpoint": "ec2.us-east-2.amazonaws.com", "RegionName": "us-east-2", "OptInStatus": "opted-in"},
+        ]
+    }
+    with open(file_path, "r") as f:
+        config = yaml.safe_load(f)
+    res: List[types.ChangeSetType] = changesets.get_ami_listing_update_changesets(
+        "test-id", config["description"], config["region"]
+    )
+    assert res[0]["DetailsDocument"]["Highlights"] == expected_desc
+
+
+@pytest.mark.parametrize(
+    "file_path, expected_desc",
+    [
+        ("./tests/test_config.yaml", ["test_keyword_1"]),
+        ("./tests/local_config/test_config_3.yaml", ["test_keyword_1", "test_keyword_2"]),
+        (
+            "./tests/local_config/test_config_4.yaml",
+            [
+                "test_keyword_1",
+                "test_keyword_2",
+                "test_keyword_3",
+                "test_keyword_4",
+                "test_keyword_5",
+                "test_keyword_6",
+            ],
+        ),
+    ],
+)
+@patch("awsmp.models.boto3")
+def test_get_ami_product_update_changeset_description_search_keywords(mock_boto3, file_path, expected_desc):
+    mock_boto3.client.return_value.describe_regions.return_value = {
+        "Regions": [
+            {"Endpoint": "ec2.us-east-1.amazonaws.com", "RegionName": "us-east-1", "OptInStatus": "opted-in"},
+            {"Endpoint": "ec2.us-east-2.amazonaws.com", "RegionName": "us-east-2", "OptInStatus": "opted-in"},
+        ]
+    }
+    with open(file_path, "r") as f:
+        config = yaml.safe_load(f)
+    res: List[types.ChangeSetType] = changesets.get_ami_listing_update_changesets(
+        "test-id", config["description"], config["region"]
+    )
+    assert res[0]["DetailsDocument"]["SearchKeywords"] == expected_desc
+
+
+@pytest.mark.parametrize(
+    "file_path, expected_desc",
+    [
+        ("./tests/test_config.yaml", ["Migration"]),
+        ("./tests/local_config/test_config_3.yaml", ["Migration", "Testing"]),
+        ("./tests/local_config/test_config_4.yaml", ["Migration", "Testing", "Blockchain"]),
+    ],
+)
+@patch("awsmp.models.boto3")
+def test_get_ami_product_update_changeset_description_categories(mock_boto3, file_path, expected_desc):
+    mock_boto3.client.return_value.describe_regions.return_value = {
+        "Regions": [
+            {"Endpoint": "ec2.us-east-1.amazonaws.com", "RegionName": "us-east-1", "OptInStatus": "opted-in"},
+            {"Endpoint": "ec2.us-east-2.amazonaws.com", "RegionName": "us-east-2", "OptInStatus": "opted-in"},
+        ]
+    }
+    with open(file_path, "r") as f:
+        config = yaml.safe_load(f)
+    res: List[types.ChangeSetType] = changesets.get_ami_listing_update_changesets(
+        "test-id", config["description"], config["region"]
+    )
+    assert res[0]["DetailsDocument"]["Categories"] == expected_desc
+
+
+@pytest.mark.parametrize(
+    "file_path, expected_desc",
+    [
+        ("./tests/test_config.yaml", [{"Text": "test-link", "Url": "https://test-url/"}]),
+        (
+            "./tests/local_config/test_config_3.yaml",
+            [{"Text": "test-link", "Url": "https://test-url/"}, {"Text": "test-link2", "Url": "https://test-url2/"}],
+        ),
+        (
+            "./tests/local_config/test_config_4.yaml",
+            [
+                {"Text": "test-link1", "Url": "https://test-url1/"},
+                {"Text": "test-link2", "Url": "https://test-url2/"},
+                {"Text": "test-link3", "Url": "https://test-url3/"},
+            ],
+        ),
+    ],
+)
+@patch("awsmp.models.boto3")
+def test_get_ami_product_update_changeset_additional_resources(mock_boto3, file_path, expected_desc):
+    mock_boto3.client.return_value.describe_regions.return_value = {
+        "Regions": [
+            {"Endpoint": "ec2.us-east-1.amazonaws.com", "RegionName": "us-east-1", "OptInStatus": "opted-in"},
+            {"Endpoint": "ec2.us-east-2.amazonaws.com", "RegionName": "us-east-2", "OptInStatus": "opted-in"},
+        ]
+    }
+    with open(file_path, "r") as f:
+        config = yaml.safe_load(f)
+    res: List[types.ChangeSetType] = changesets.get_ami_listing_update_changesets(
+        "test-id", config["description"], config["region"]
+    )
+    assert res[0]["DetailsDocument"]["AdditionalResources"] == expected_desc
+
+
+@pytest.mark.parametrize(
+    "file_path, expected_desc",
+    [
+        ("./tests/test_config.yaml", "test_support_description"),
+        ("./tests/local_config/test_config_3.yaml", "test_support_description\n\nwith new lines"),
+        ("./tests/local_config/test_config_4.yaml", "test_support_description\nwith multiple line\nlines"),
+    ],
+)
+@patch("awsmp.models.boto3")
+def test_get_ami_product_update_changeset_support_desc(mock_boto3, file_path, expected_desc):
+    mock_boto3.client.return_value.describe_regions.return_value = {
+        "Regions": [
+            {"Endpoint": "ec2.us-east-1.amazonaws.com", "RegionName": "us-east-1", "OptInStatus": "opted-in"},
+            {"Endpoint": "ec2.us-east-2.amazonaws.com", "RegionName": "us-east-2", "OptInStatus": "opted-in"},
+        ]
+    }
+    with open(file_path, "r") as f:
+        config = yaml.safe_load(f)
+    res: List[types.ChangeSetType] = changesets.get_ami_listing_update_changesets(
+        "test-id", config["description"], config["region"]
+    )
+    assert res[0]["DetailsDocument"]["SupportDescription"] == expected_desc
+
+
+@pytest.mark.parametrize(
+    "file_path, expected_desc",
+    [
+        ("./tests/test_config.yaml", []),
+        ("./tests/local_config/test_config_3.yaml", ["https://test-video"]),
+        ("./tests/local_config/test_config_4.yaml", []),
+    ],
+)
+@patch("awsmp.models.boto3")
+def test_get_ami_product_update_changeset_optional_video_urls(mock_boto3, file_path, expected_desc):
+    mock_boto3.client.return_value.describe_regions.return_value = {
+        "Regions": [
+            {"Endpoint": "ec2.us-east-1.amazonaws.com", "RegionName": "us-east-1", "OptInStatus": "opted-in"},
+            {"Endpoint": "ec2.us-east-2.amazonaws.com", "RegionName": "us-east-2", "OptInStatus": "opted-in"},
+        ]
+    }
+    with open(file_path, "r") as f:
+        config = yaml.safe_load(f)
+    res: List[types.ChangeSetType] = changesets.get_ami_listing_update_changesets(
+        "test-id", config["description"], config["region"]
+    )
+    assert res[0]["DetailsDocument"]["VideoUrls"] == expected_desc
+
+
+@pytest.mark.parametrize(
+    "file_path, expected_region",
+    [
+        ("./tests/test_config.yaml", ["us-east-1", "us-east-2"]),
+        ("./tests/local_config/test_config_3.yaml", ["us-east-1"]),
+        ("./tests/local_config/test_config_4.yaml", ["us-east-2"]),
+    ],
+)
+@patch("awsmp.models.boto3")
+def test_get_ami_product_update_changeset_region(mock_boto3, file_path, expected_region):
+    mock_boto3.client.return_value.describe_regions.return_value = {
+        "Regions": [
+            {"Endpoint": "ec2.us-east-1.amazonaws.com", "RegionName": "us-east-1", "OptInStatus": "opted-in"},
+            {"Endpoint": "ec2.us-east-2.amazonaws.com", "RegionName": "us-east-2", "OptInStatus": "opted-in"},
+        ]
+    }
+    with open(file_path, "r") as f:
+        config = yaml.safe_load(f)
+    res: List[types.ChangeSetType] = changesets.get_ami_listing_update_changesets(
+        "test-id", config["description"], config["region"]
+    )
+    assert res[1]["DetailsDocument"]["Regions"] == expected_region
+
+
+@pytest.mark.parametrize(
+    "file_path, expected_future_region",
+    [
+        ("./tests/test_config.yaml", ["All"]),
+        ("./tests/local_config/test_config_3.yaml", ["None"]),
+        ("./tests/local_config/test_config_4.yaml", ["All"]),
+    ],
+)
+@patch("awsmp.models.boto3")
+def test_get_ami_product_update_changeset_future_region(mock_boto3, file_path, expected_future_region):
+    mock_boto3.client.return_value.describe_regions.return_value = {
+        "Regions": [
+            {"Endpoint": "ec2.us-east-1.amazonaws.com", "RegionName": "us-east-1", "OptInStatus": "opted-in"},
+            {"Endpoint": "ec2.us-east-2.amazonaws.com", "RegionName": "us-east-2", "OptInStatus": "opted-in"},
+        ]
+    }
+    with open(file_path, "r") as f:
+        config = yaml.safe_load(f)
+    res: List[types.ChangeSetType] = changesets.get_ami_listing_update_changesets(
+        "test-id", config["description"], config["region"]
+    )
+    assert res[2]["DetailsDocument"]["FutureRegionSupport"]["SupportedRegions"] == expected_future_region
+
+
+@patch("awsmp.models.boto3")
+def test_get_ami_product_update_non_valid_changeset(mock_boto3):
+    mock_boto3.client.return_value.describe_regions.return_value = {
+        "Regions": [
+            {"Endpoint": "ec2.us-east-1.amazonaws.com", "RegionName": "us-east-1", "OptInStatus": "opted-in"},
+            {"Endpoint": "ec2.us-east-2.amazonaws.com", "RegionName": "us-east-2", "OptInStatus": "opted-in"},
+        ]
+    }
+
+    with pytest.raises(ValidationError):
+        changesets.get_ami_listing_update_changesets("test-id", {}, {})

--- a/tests/test_changesets.py
+++ b/tests/test_changesets.py
@@ -14,7 +14,7 @@ from awsmp import changesets, types
 )
 def test_changeset_update_legal_terms_eula_options(eula_url, expected):
     result = changesets._changeset_update_legal_terms(eula_url=eula_url)
-    result["Details"]["Terms"][0] == expected  # type: ignore
+    result["DetailsDocument"]["Terms"][0] == expected  # type: ignore
 
 
 @pytest.mark.parametrize(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,13 +7,49 @@ import pytest
 import yaml
 from click.testing import CliRunner
 
-from awsmp import _driver, cli, errors, models
+from awsmp import _driver, changesets, cli, errors, models
 
 
 @patch("awsmp._driver.get_client")
 def test_offer_pricing_template(mock_get_client):
     mock_get_client.return_value.describe_entity.return_value = {
-        "Details": '{"Terms":[{"Type":"UsageBasedPricingTerm","Id":"usage_id","CurrencyCode":"USD","RateCards":[{"RateCard":[{"DimensionKey":"m6i.xlarge","Price":"0.007"},{"DimensionKey":"t2.nano","Price":"0.002"},{"DimensionKey":"r5d.24xlarge","Price":"0.168"}]}]},{"Type":"ConfigurableUpfrontPricingTerm","Id":"annual_id","CurrencyCode":"USD","RateCards":[{"Selector":{"Type":"Duration","Value":"P365D"},"Constraints":{"MultipleDimensionSelection":"Allowed","QuantityConfiguration":"Allowed"},"RateCard":[{"DimensionKey":"m6i.xlarge","Price":"49.056"},{"DimensionKey":"t2.nano","Price":"12.264"},{"DimensionKey":"r5d.24xlarge","Price":"1177.344"}]}]}]}'
+        "DetailsDocument": {
+            "Terms": [
+                {
+                    "Type": "UsageBasedPricingTerm",
+                    "Id": "usage_id",
+                    "CurrencyCode": "USD",
+                    "RateCards": [
+                        {
+                            "RateCard": [
+                                {"DimensionKey": "m6i.xlarge", "Price": "0.007"},
+                                {"DimensionKey": "t2.nano", "Price": "0.002"},
+                                {"DimensionKey": "r5d.24xlarge", "Price": "0.168"},
+                            ]
+                        }
+                    ],
+                },
+                {
+                    "Type": "ConfigurableUpfrontPricingTerm",
+                    "Id": "annual_id",
+                    "CurrencyCode": "USD",
+                    "RateCards": [
+                        {
+                            "Selector": {"Type": "Duration", "Value": "P365D"},
+                            "Constraints": {
+                                "MultipleDimensionSelection": "Allowed",
+                                "QuantityConfiguration": "Allowed",
+                            },
+                            "RateCard": [
+                                {"DimensionKey": "m6i.xlarge", "Price": "49.056"},
+                                {"DimensionKey": "t2.nano", "Price": "12.264"},
+                                {"DimensionKey": "r5d.24xlarge", "Price": "1177.344"},
+                            ],
+                        }
+                    ],
+                },
+            ]
+        }
     }
     runner = CliRunner()
     pricing_file = tempfile.NamedTemporaryFile()
@@ -42,10 +78,10 @@ def test_offer_create(mock_get_client, mock_get_entity_details):
             prices,
         )
     mock_start_change_set = mock_get_client.return_value.start_change_set
-    assert (
-        '{"RateCard": [{"DimensionKey": "c3.2xlarge", "Price": "0.014"}, {"DimensionKey": "c3.4xlarge", "Price": "0.028"}]}'
-        in mock_start_change_set.call_args_list[0].kwargs["ChangeSet"][3]["Details"]
-    )
+
+    assert {
+        "RateCard": [{"DimensionKey": "c3.2xlarge", "Price": "0.014"}, {"DimensionKey": "c3.4xlarge", "Price": "0.028"}]
+    } == mock_start_change_set.call_args_list[0].kwargs["ChangeSet"][3]["DetailsDocument"]["Terms"][0]["RateCards"][0]
 
 
 def test_ami_product_instance_type_template():

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -60,7 +60,7 @@ def test_filter_instance_types(mock_get_details):
         None,
         None,
         None,
-        {"Details": {"Terms": [ratecards, ratecards]}},
+        {"DetailsDocument": {"Terms": [ratecards, ratecards]}},
     ]
     res = _driver._filter_instance_types("product-id", changeset)
     assert res == changeset
@@ -74,7 +74,7 @@ def test_filter_instance_types_missing_types(mock_get_details):
         None,
         None,
         None,
-        {"Details": {"Terms": [ratecards, ratecards]}},
+        {"DetailsDocument": {"Terms": [ratecards, ratecards]}},
     ]
     with pytest.raises(MissingInstanceTypeError):
         _driver._filter_instance_types("product-id", changeset)
@@ -129,8 +129,8 @@ def test_ami_product_update_description(mock_get_client):
     mock_start_change_set = mock_get_client.return_value.start_change_set
 
     assert (
-        '"LogoUrl": "https://awsmp-logos.s3.amazonaws.com/8350ae04bad5625623cc02c64eb8b0b5"'
-        in mock_start_change_set.call_args_list[0].kwargs["ChangeSet"][0]["Details"]
+        mock_start_change_set.call_args_list[0].kwargs["ChangeSet"][0]["DetailsDocument"]["LogoUrl"]
+        == "https://awsmp-logos.s3.amazonaws.com/8350ae04bad5625623cc02c64eb8b0b5"
     )
 
 
@@ -168,13 +168,18 @@ def test_ami_product_update_instance_type(mock_get_details, mock_get_client):
     with open("./tests/prices.csv") as prices:
         ap.update_instance_types(prices, "Hrs", True)
     assert mock_get_client.return_value.start_change_set.call_count == 1
+    assert mock_get_client.return_value.start_change_set.call_args_list[0].kwargs["ChangeSet"][1][
+        "DetailsDocument"
+    ] == {"InstanceTypes": ["c4.large"]}
     assert (
-        mock_get_client.return_value.start_change_set.call_args_list[0].kwargs["ChangeSet"][1]["Details"]
-        == '{"InstanceTypes": ["c4.large"]}'
-    )
-    assert (
-        '{"DimensionKey": "c4.large", "Price": "0.00"}'
-        in mock_get_client.return_value.start_change_set.call_args_list[0].kwargs["ChangeSet"][2]["Details"]
+        mock_get_client.return_value.start_change_set.call_args_list[0].kwargs["ChangeSet"][2]["DetailsDocument"][
+            "Terms"
+        ][0]["RateCards"][0]["RateCard"][-1]["DimensionKey"]
+        == "c4.large"
+        and mock_get_client.return_value.start_change_set.call_args_list[0].kwargs["ChangeSet"][2]["DetailsDocument"][
+            "Terms"
+        ][0]["RateCards"][0]["RateCard"][-1]["Price"]
+        == "0.00"
     )
 
 
@@ -228,14 +233,12 @@ def test_ami_product_update_region_valid_values(mock_boto3, mock_get_client, val
     ap.update_regions(mock_region_config)
 
     assert mock_get_client.return_value.start_change_set.call_count == 1
-    assert (
-        mock_get_client.return_value.start_change_set.call_args_list[0].kwargs["ChangeSet"][0]["Details"]
-        == '{"Regions": ["eu-north-1"]}'
-    )
-    assert (
-        mock_get_client.return_value.start_change_set.call_args_list[0].kwargs["ChangeSet"][1]["Details"]
-        == '{"FutureRegionSupport": {"SupportedRegions": ["All"]}}'
-    )
+    assert mock_get_client.return_value.start_change_set.call_args_list[0].kwargs["ChangeSet"][0][
+        "DetailsDocument"
+    ] == {"Regions": ["eu-north-1"]}
+    assert mock_get_client.return_value.start_change_set.call_args_list[0].kwargs["ChangeSet"][1][
+        "DetailsDocument"
+    ] == {"FutureRegionSupport": {"SupportedRegions": ["All"]}}
 
 
 @pytest.mark.parametrize(
@@ -296,10 +299,24 @@ def test_ami_product_update_version(mock_get_client):
     ap.update_version(mock_version_config)
 
     assert mock_get_client.return_value.start_change_set.call_count == 1
-    assert (
-        '"AmiDeliveryOptionDetails": {"AmiSource": {"AmiId": "ami-sample", "AccessRoleArn": "arn:aws:iam::testingrole", "UserName": "testing", "OperatingSystemName": "TESTING SYSTEM", "OperatingSystemVersion": "testing version", "ScanningPort": 22}'
-        in mock_get_client.return_value.start_change_set.call_args_list[0].kwargs["ChangeSet"][0]["Details"]
-    )
+    assert {
+        "AmiId": "ami-sample",
+        "AccessRoleArn": "arn:aws:iam::testingrole",
+        "UserName": "testing",
+        "OperatingSystemName": "TESTING SYSTEM",
+        "OperatingSystemVersion": "testing version",
+        "ScanningPort": 22,
+    } == mock_get_client.return_value.start_change_set.call_args_list[0].kwargs["ChangeSet"][0]["DetailsDocument"][
+        "DeliveryOptions"
+    ][
+        0
+    ][
+        "Details"
+    ][
+        "AmiDeliveryOptionDetails"
+    ][
+        "AmiSource"
+    ]
 
 
 @patch("awsmp._driver.get_client")
@@ -309,10 +326,18 @@ def test_ami_product_update_legal_terms(mock_get_client):
     ap = _driver.AmiProduct(product_id="testing")
     ap.update_legal_terms(eula_url=mock_eula)
 
-    assert (
-        '{"Type": "CustomEula", "Url": "https://testing-eula"}'
-        in mock_get_client.return_value.start_change_set.call_args_list[0].kwargs["ChangeSet"][0]["Details"]
-    )
+    assert {
+        "Type": "CustomEula",
+        "Url": "https://testing-eula",
+    } == mock_get_client.return_value.start_change_set.call_args_list[0].kwargs["ChangeSet"][0]["DetailsDocument"][
+        "Terms"
+    ][
+        0
+    ][
+        "Documents"
+    ][
+        0
+    ]
 
 
 @patch("awsmp._driver.get_client")
@@ -321,10 +346,9 @@ def test_ami_product_update_support_terms(mock_get_client):
     ap = _driver.AmiProduct(product_id="testing")
     ap.update_support_terms(refund_policy=mock_refund_policy)
 
-    assert (
-        '{"Terms": [{"Type": "SupportTerm", "RefundPolicy": "testing is not refundable"}]}'
-        == mock_get_client.return_value.start_change_set.call_args_list[0].kwargs["ChangeSet"][0]["Details"]
-    )
+    assert {
+        "Terms": [{"Type": "SupportTerm", "RefundPolicy": "testing is not refundable"}]
+    } == mock_get_client.return_value.start_change_set.call_args_list[0].kwargs["ChangeSet"][0]["DetailsDocument"]
 
 
 @patch("awsmp._driver.get_client")

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -365,3 +365,29 @@ def test_get_public_no_offer_id(mock_get_client):
     mock_get_client.return_value.list_entities.return_value = {"EntitySummaryList": []}
     with pytest.raises(ResourceNotFoundException):
         _driver.get_public_offer_id("no-offer-id")
+
+
+@patch("awsmp._driver.get_client")
+@patch("awsmp._driver.changesets.models.boto3")
+def test_ami_product_update(mock_boto3, mock_get_client):
+    with open("./tests/test_config.yaml", "r") as f:
+        config = yaml.safe_load(f)
+
+    mock_boto3.client.return_value.describe_regions.return_value = {
+        "Regions": [
+            {"Endpoint": "ec2.us-east-1.amazonaws.com", "RegionName": "us-east-1", "OptInStatus": "opted-in"},
+            {"Endpoint": "ec2.us-east-2.amazonaws.com", "RegionName": "us-east-2", "OptInStatus": "opted-in"},
+        ]
+    }
+
+    ap = _driver.AmiProduct(product_id="testing")
+    ap.update(config)
+    mock_start_change_set = mock_get_client.return_value.start_change_set
+
+    assert (
+        "https://test-logourl"
+        == mock_start_change_set.call_args_list[0].kwargs["ChangeSet"][0]["DetailsDocument"]["LogoUrl"]
+    )
+    assert {"Regions": ["us-east-1", "us-east-2"]} == mock_start_change_set.call_args_list[0].kwargs["ChangeSet"][1][
+        "DetailsDocument"
+    ]


### PR DESCRIPTION
### Description

Add a `update` command to support sending multiple requests to update an AMI product listing. Currently, it only supports updating the description and region availability.

The product ID and configuration file should be passed to the CLI:

`awsmp public-offer update --product-id xxxx --config local_config.yaml`

I manually tested these steps by running the command with different configurations and verifying that the description and region availability were correctly updated in the listing.