### PR TITLE
fix: Increase title underline to avoid a warning

### DIFF
--- a/docs/inspect/index.rst
+++ b/docs/inspect/index.rst
@@ -5,7 +5,7 @@ To manage existing offers in `AWS marketplace management portal`_, use the API c
 
 
 Identify differences in public offer
------------------------------------
+------------------------------------
 
 Before requesting changes to a public offer, compare the listing information in the `AWS marketplace management portal`_ with
 the local configuration file to avoid unnecessary modifications.


### PR DESCRIPTION
The 'Manage offer' page is not being rendered. I want to check if this happening due to a warning related to an underline being too short. (The page renders fine locally)