### PR TITLE
fix!: Remove dimension-unit option from cli

### DIFF
--- a/awsmp/changesets.py
+++ b/awsmp/changesets.py
@@ -1,7 +1,7 @@
 import datetime
 import json
 from decimal import Decimal
-from typing import Any, Dict, List, Literal, Optional, TypedDict, Union
+from typing import Any, Dict, List, Optional, TypedDict, Union
 
 import boto3
 from pydantic import BaseModel, Field, HttpUrl, conlist, field_validator
@@ -296,7 +296,7 @@ def _changeset_update_ami_product_future_region(product_id: str, region_config: 
     }
 
 
-def _build_metered_instance_unit(instance_type: str, dimension_unit: Literal["Hrs", "Units"]) -> UpdateDimensionChange:
+def _build_metered_instance_unit(instance_type: str) -> UpdateDimensionChange:
     return {
         "Description": instance_type,
         "Key": instance_type,
@@ -304,16 +304,14 @@ def _build_metered_instance_unit(instance_type: str, dimension_unit: Literal["Hr
         "Types": [
             "Metered",
         ],
-        "Unit": dimension_unit,
+        "Unit": "Hrs",
     }
 
 
-def _changeset_update_ami_product_dimension(
-    product_id: str, dimension_unit: Literal["Hrs", "Units"], new_instance_types: List[str]
-):
+def _changeset_update_ami_product_dimension(product_id: str, new_instance_types: List[str]):
     # generate dimension list
     dimension_changeset: List[UpdateDimensionChange] = [
-        _build_metered_instance_unit(instance_type, dimension_unit) for instance_type in new_instance_types
+        _build_metered_instance_unit(instance_type) for instance_type in new_instance_types
     ]
 
     return {
@@ -457,7 +455,6 @@ def get_ami_listing_update_instance_type_changesets(
     product_id: str,
     offer_id: str,
     offer_detail: models.Offer,
-    dimension_unit: Literal["Hrs", "Units"],
     new_instance_types: List[str],
     removed_instance_types: List[str],
 ) -> List[ChangeSetType]:
@@ -466,7 +463,6 @@ def get_ami_listing_update_instance_type_changesets(
     :param str product_id: product id
     :param str offer_id: offer id
     :param models.Offer offer_detail: offer configuration in local confi file
-    :param Literal["Hrs", "Units"] dimension_unit: dimension unit of instance types
     :param List[str] new_instance_types: list of instance types to add to the listing
     :param List[str] removed_instance_types: list of instance types to remove from the listing
     :return: List of Changesets
@@ -483,7 +479,7 @@ def get_ami_listing_update_instance_type_changesets(
     if new_instance_types:
         changeset_list.extend(
             [
-                _changeset_update_ami_product_dimension(product_id, dimension_unit, new_instance_types),
+                _changeset_update_ami_product_dimension(product_id, new_instance_types),
                 _changeset_update_ami_product_instance_type(product_id, new_instance_types),
             ]
         )

--- a/awsmp/cli.py
+++ b/awsmp/cli.py
@@ -4,7 +4,7 @@ import csv
 import json
 import logging
 import time
-from typing import Dict, List, Literal, Optional, TextIO
+from typing import Dict, List, Optional, TextIO
 
 import click
 import prettytable
@@ -277,7 +277,6 @@ def ami_product_update_description(product_id, config):
 @public_offer.command("update-instance-type")
 @click.option("--product-id", required=True, prompt=True)
 @click.option("--config", type=click.File("r"), required=True, prompt=True)
-@click.option("--dimension-unit", required=True, prompt=True, type=click.Choice(["Hrs", "Units"]))
 @click.option(
     "--allow-price-change",
     required=True,
@@ -286,21 +285,18 @@ def ami_product_update_description(product_id, config):
     is_flag=True,
     prompt="Is price update allowed? (y). Default is False.",
 )
-def ami_product_update_instance_type(
-    product_id: str, config: TextIO, dimension_unit: Literal["Hrs", "Units"], allow_price_change: bool
-) -> None:
+def ami_product_update_instance_type(product_id: str, config: TextIO, allow_price_change: bool) -> None:
     """
     Update AMI product instance type
     :param str product_id: Id of listing
     :param TextIO config: file path of local configuration file
-    :param Literal["Hrs", "Units"] dimension_unit: Unit of a instance type
     :param bool allow_price_change: flag of allowing pricing change to update instance type information
     :return: None
     :rtype: None
     """
     product = _driver.AmiProduct(product_id=product_id)
     offer_config = _load_configuration(config, [["offer"]])["offer"]
-    response = product.update_instance_types(offer_config, dimension_unit, allow_price_change)
+    response = product.update_instance_types(offer_config, allow_price_change)
     if response:
         print(f'ChangeSet created (ID: {response["ChangeSetId"]})')
         print(f'https://aws.amazon.com/marketplace/management/requests/{response["ChangeSetId"]}')
@@ -420,7 +416,6 @@ def ami_product_release(product_id):
 @public_offer.command("update")
 @click.option("--product-id", required=True, prompt=True)
 @click.option("--config", type=click.File("r"), required=True, prompt=True)
-@click.option("--dimension-unit", required=True, prompt=True, type=click.Choice(["Hrs", "Units"]))
 @click.option(
     "--allow-price-change",
     required=True,
@@ -428,14 +423,11 @@ def ami_product_release(product_id):
     is_flag=True,
     prompt="Is price update allowed? (y/N). Default is False.",
 )
-def ami_product_update(
-    product_id: str, config: TextIO, dimension_unit: Literal["Hrs", "Units"], allow_price_change: bool
-) -> None:
+def ami_product_update(product_id: str, config: TextIO, allow_price_change: bool) -> None:
     """
     Update AMI product details (description, region, instnance type and pricing) in a single call
     :param str product_id: Id of listing
     :param TextIO config: file path of local configuration file
-    :param Literal["Hrs", "Units"] dimension_unit: Unit of a instance type
     :param bool allow_price_change: flag of allowing pricing change to update instance type information
     :return: None
     :rtype: None
@@ -444,7 +436,7 @@ def ami_product_update(
     # Load yaml file
     configs = _load_configuration(config, [["product", "description"], ["product", "region"], ["offer"]])
     product = _driver.AmiProduct(product_id=product_id)
-    response = product.update(configs, dimension_unit, allow_price_change)
+    response = product.update(configs, allow_price_change)
 
     if response:
         print(f'ChangeSet created (ID: {response["ChangeSetId"]})')

--- a/docs/public-offer/index.rst
+++ b/docs/public-offer/index.rst
@@ -114,11 +114,8 @@ Once offer field is ready, run the command:
          awsmp public-offer update-instance-type \
             --product-id prod-xwpv7txqxg55e \
             --config listing_configuration.yaml \
-            --dimension-unit Hrs \
             --allow-price-change
 
-
-Different billing unit types are possible, but the currently supported types are ``Hrs`` and ``Units``.
 
 The CLI retrieves the added and removed instance types from the configuration by comparing it with the existing listing, then sends the appropriate add/restrict instance type requests.
 It also compares the pricing before sending a request to avoid unnecessary price changes (increases or decreases) in the listing. To update the price, pass the `--price_change-allowed` flag.

--- a/tests/test_changesets.py
+++ b/tests/test_changesets.py
@@ -405,7 +405,7 @@ def test_get_ami_listing_update_instance_type_changesets_add_new_instance_type()
     }
     offer_detail = models.Offer(**offer_config)
     res: List[types.ChangeSetType] = changesets.get_ami_listing_update_instance_type_changesets(
-        "test-id", "test-offer_id", offer_detail, "Hrs", ["c4.large"], []
+        "test-id", "test-offer_id", offer_detail, ["c4.large"], []
     )
     details_document = [cast(Dict[str, Any], item["DetailsDocument"]) for item in res[:]]
     assert (
@@ -429,7 +429,7 @@ def test_get_ami_listing_update_instance_type_changesets_add_new_multiple_instan
     }
     offer_detail = models.Offer(**offer_config)
     res: List[types.ChangeSetType] = changesets.get_ami_listing_update_instance_type_changesets(
-        "test-id", "test-offer_id", offer_detail, "Hrs", ["c4.large", "c5.large"], []
+        "test-id", "test-offer_id", offer_detail, ["c4.large", "c5.large"], []
     )
     details_document = [cast(Dict[str, Any], item["DetailsDocument"]) for item in res[:]]
     assert (
@@ -453,7 +453,7 @@ def test_get_ami_listing_update_instance_type_changesets_add_new_instance_type_w
     }
     offer_detail = models.Offer(**offer_config)
     res: List[types.ChangeSetType] = changesets.get_ami_listing_update_instance_type_changesets(
-        "test-id", "test-offer_id", offer_detail, "Hrs", ["c4.large"], []
+        "test-id", "test-offer_id", offer_detail, ["c4.large"], []
     )
     details_document = [cast(Dict[str, Any], item["DetailsDocument"]) for item in res[:]]
     assert details_document[0]["Terms"][0]["RateCards"][0]["RateCard"][1] == {
@@ -477,7 +477,7 @@ def test_get_ami_listing_update_instance_type_changesets_restrict_instance_type(
     }
     offer_detail = models.Offer(**offer_config)
     res: List[types.ChangeSetType] = changesets.get_ami_listing_update_instance_type_changesets(
-        "test-id", "test-offer_id", offer_detail, "Hrs", [], ["c4.large"]
+        "test-id", "test-offer_id", offer_detail, [], ["c4.large"]
     )
     details_document = [cast(Any, item["DetailsDocument"]) for item in res[:]]
 
@@ -499,7 +499,7 @@ def test_get_ami_listing_update_instance_type_changesets_restrict_multiple_insta
     }
     offer_detail = models.Offer(**offer_config)
     res: List[types.ChangeSetType] = changesets.get_ami_listing_update_instance_type_changesets(
-        "test-id", "test-offer_id", offer_detail, "Hrs", [], ["c4.large", "c5.large"]
+        "test-id", "test-offer_id", offer_detail, [], ["c4.large", "c5.large"]
     )
     details_document = [cast(Any, item["DetailsDocument"]) for item in res[:]]
 
@@ -523,7 +523,7 @@ def test_get_ami_listing_update_instance_type_changesets_restrict_and_add_instan
     }
     offer_detail = models.Offer(**offer_config)
     res: List[types.ChangeSetType] = changesets.get_ami_listing_update_instance_type_changesets(
-        "test-id", "test-offer_id", offer_detail, "Hrs", ["c4.large"], ["c1.medium"]
+        "test-id", "test-offer_id", offer_detail, ["c4.large"], ["c1.medium"]
     )
     details_document = [cast(Any, item["DetailsDocument"]) for item in res[:]]
     assert (
@@ -546,7 +546,7 @@ def test_get_ami_listing_update_instance_type_changesets_no_restrict_and_add_ins
     }
     offer_detail = models.Offer(**offer_config)
     res: List[types.ChangeSetType] = changesets.get_ami_listing_update_instance_type_changesets(
-        "test-id", "test-offer_id", offer_detail, "Hrs", [], []
+        "test-id", "test-offer_id", offer_detail, [], []
     )
     assert (
         res[0]["ChangeType"] == "UpdatePricingTerms"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -340,7 +340,7 @@ def test_public_offer_product_update_details(mock_get_client, mock_get_details, 
     runner = CliRunner()
     runner.invoke(
         cli.ami_product_update,
-        ["--product-id", "some-prod-id", "--config", "./tests/test_config.yaml", "--dimension-unit", "Hrs"],
+        ["--product-id", "some-prod-id", "--config", "./tests/test_config.yaml"],
     )
     mock_start_change_set = mock_get_client.return_value.start_change_set
     assert {"Regions": ["us-east-1", "us-east-2"]} == mock_start_change_set.call_args_list[0].kwargs["ChangeSet"][1][
@@ -402,14 +402,7 @@ def test_public_offer_product_update_details_pricing_change(mock_get_client, moc
     with caplog.at_level("ERROR", logger="awsmp._driver"):
         runner.invoke(
             cli.ami_product_update,
-            [
-                "--product-id",
-                "some-prod-id",
-                "--config",
-                "./tests/test_config.yaml",
-                "--dimension-unit",
-                "Hrs",
-            ],
+            ["--product-id", "some-prod-id", "--config", "./tests/test_config.yaml"],
         )
 
     assert any(
@@ -458,14 +451,7 @@ def test_public_offer_product_update_details_raise_exception(mock_get_client, mo
     with pytest.raises(errors.AmiPriceChangeError) as excInfo:
         runner.invoke(
             cli.ami_product_update,
-            [
-                "--product-id",
-                "some-prod-id",
-                "--config",
-                "./tests/test_config.yaml",
-                "--dimension-unit",
-                "Hrs",
-            ],
+            ["--product-id", "some-prod-id", "--config", "./tests/test_config.yaml"],
             catch_exceptions=False,
         )
 
@@ -525,14 +511,7 @@ def test_public_offer_product_update_details_restrict_instance_types(mock_get_cl
 
     runner.invoke(
         cli.ami_product_update,
-        [
-            "--product-id",
-            "some-prod-id",
-            "--config",
-            "./tests/test_config.yaml",
-            "--dimension-unit",
-            "Hrs",
-        ],
+        ["--product-id", "some-prod-id", "--config", "./tests/test_config.yaml"],
     )
     mock_start_change_set = mock_get_client.return_value.start_change_set
     assert (
@@ -599,8 +578,6 @@ def test_public_offer_product_update_details_pricing_change_allowed(
             "some-prod-id",
             "--config",
             "./tests/test_config.yaml",
-            "--dimension-unit",
-            "Hrs",
             "--allow-price-change",
         ],
     )
@@ -668,8 +645,6 @@ def test_public_offer_product_update_instance_type(mock_get_client, mock_get_det
             "some-prod-id",
             "--config",
             "./tests/test_config.yaml",
-            "--dimension-unit",
-            "Hrs",
         ],
     )
     mock_start_change_set = mock_get_client.return_value.start_change_set
@@ -740,8 +715,6 @@ def test_public_offer_product_update_instance_type_restrict_instance_type(
             "some-prod-id",
             "--config",
             "./tests/test_config.yaml",
-            "--dimension-unit",
-            "Hrs",
         ],
     )
     mock_start_change_set = mock_get_client.return_value.start_change_set
@@ -808,8 +781,6 @@ def test_public_offer_product_update_instance_type_pricing_change(mock_get_clien
             "some-prod-id",
             "--config",
             "./tests/test_config.yaml",
-            "--dimension-unit",
-            "Hrs",
             "--allow-price-change",
         ],
     )
@@ -874,14 +845,7 @@ def test_public_offer_product_update_instance_type_pricing_change_not_allowed(
     runner = CliRunner()
     res = runner.invoke(
         cli.ami_product_update_instance_type,
-        [
-            "--product-id",
-            "some-prod-id",
-            "--config",
-            "./tests/test_config.yaml",
-            "--dimension-unit",
-            "Hrs",
-        ],
+        ["--product-id", "some-prod-id", "--config", "./tests/test_config.yaml"],
     )
     assert res.return_value == None
 
@@ -927,13 +891,6 @@ def test_public_offer_product_update_instance_type_pricing_change_exception(
     runner = CliRunner()
     res = runner.invoke(
         cli.ami_product_update_instance_type,
-        [
-            "--product-id",
-            "some-prod-id",
-            "--config",
-            "./tests/test_config.yaml",
-            "--dimension-unit",
-            "Hrs",
-        ],
+        ["--product-id", "some-prod-id", "--config", "./tests/test_config.yaml"],
     )
     assert res.exit_code == 1 and res.exc_info is not None and "Contact AWS" in res.exc_info[1].args[0]

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -212,7 +212,7 @@ def test_ami_product_update_instance_type(mock_get_details, mock_get_client):
     mock_get_client.return_value.list_entities.return_value = {
         "EntitySummaryList": [{"EntityType": "Offer", "EntityId": "test-offer"}]
     }
-    res = ap.update_instance_types(offer_config, "Hrs", False)
+    res = ap.update_instance_types(offer_config, False)
 
     assert mock_get_client.return_value.start_change_set.call_count == 1
     assert mock_get_client.return_value.start_change_set.call_args_list[0].kwargs["ChangeSet"][2][
@@ -277,7 +277,7 @@ def test_ami_product_update_instance_type_restrict_instance_type(mock_get_detail
         "refund_policy": "refund_policy",
         "eula_document": [{"type": "StandardEula", "version": "2025-04-05"}],
     }
-    res = ap.update_instance_types(offer_config, "Hrs", False)
+    res = ap.update_instance_types(offer_config, False)
 
     assert mock_get_client.return_value.start_change_set.call_count == 1
     assert mock_get_client.return_value.start_change_set.call_args_list[0].kwargs["ChangeSet"][1][
@@ -333,7 +333,7 @@ def test_ami_product_update_instance_type_restrict_and_add_instance_type(mock_ge
         "refund_policy": "refund_policy",
         "eula_document": [{"type": "StandardEula", "version": "2025-04-05"}],
     }
-    res = ap.update_instance_types(offer_config, "Hrs", False)
+    res = ap.update_instance_types(offer_config, False)
 
     assert mock_get_client.return_value.start_change_set.call_count == 1
     assert (
@@ -402,7 +402,7 @@ def test_ami_product_update_instance_type_pricing_update(mock_get_details, mock_
     mock_get_client.return_value.list_entities.return_value = {
         "EntitySummaryList": [{"EntityType": "Offer", "EntityId": "test-offer"}]
     }
-    res = ap.update_instance_types(offer_config, "Hrs", False)
+    res = ap.update_instance_types(offer_config, False)
     assert res == None
 
 
@@ -453,7 +453,7 @@ def test_ami_product_update_instance_type_restrict_and_add_instance_type_pricing
         "refund_policy": "refund_policy",
         "eula_document": [{"type": "StandardEula", "version": "2025-04-05"}],
     }
-    res = ap.update_instance_types(offer_config, "Hrs", True)
+    res = ap.update_instance_types(offer_config, True)
 
     assert mock_get_client.return_value.start_change_set.call_count == 1
     assert (
@@ -513,7 +513,7 @@ def test_ami_product_update_instance_type_pricing_update_exception(mock_get_deta
         "eula_document": [{"type": "StandardEula", "version": "2025-04-05"}],
     }
     with pytest.raises(AmiPriceChangeError) as excInfo:
-        ap.update_instance_types(offer_config, "Hrs", True)
+        ap.update_instance_types(offer_config, True)
     assert "Contact AWS Marketplace" in excInfo.value.args[0]
 
 
@@ -1371,7 +1371,7 @@ def test_ami_product_update(mock_boto3, mock_get_details, mock_get_client):
     }
 
     ap = _driver.AmiProduct(product_id="testing")
-    ap.update(config, "Hrs", False)
+    ap.update(config, False)
     mock_start_change_set = mock_get_client.return_value.start_change_set
 
     assert (
@@ -1433,7 +1433,7 @@ def test_ami_product_update_pricing_change(mock_boto3, mock_get_details, mock_ge
     }
 
     ap = _driver.AmiProduct(product_id="testing")
-    res = ap.update(config, "Hrs", False)
+    res = ap.update(config, False)
 
     assert res == None
 
@@ -1479,7 +1479,7 @@ def test_ami_product_update_pricing_exception_by_adding_yearly_price(mock_boto3,
     ap = _driver.AmiProduct(product_id="testing")
 
     with pytest.raises(AmiPriceChangeError) as excInfo:
-        ap.update(config, "Hrs", False)
+        ap.update(config, False)
 
     assert "Contact AWS Marketplace" in excInfo.value.args[0]
 
@@ -1536,7 +1536,7 @@ def test_ami_product_update_restrict_instance_types(mock_boto3, mock_get_details
     }
 
     ap = _driver.AmiProduct(product_id="testing")
-    ap.update(config, "Hrs", False)
+    ap.update(config, False)
     mock_start_change_set = mock_get_client.return_value.start_change_set
 
     assert mock_start_change_set.call_args_list[0].kwargs["ChangeSet"][4][


### PR DESCRIPTION
The dimension-unit option was previously available in the public-offer `update-instance-type` and
`update` CLI commands.

However, the `Unit` option is not available to configure, as AMI product listings only support "Hrs" as the
dimension unit for pricing.

BREAKING-CHANGE: 'dimension-unit' option is removed from invalid config for AMI product listings.