### PR TITLE
feat: avoid pricing configuration mismatches

### DIFF
--- a/awsmp/models.py
+++ b/awsmp/models.py
@@ -140,22 +140,62 @@ class Offer(BaseModel):
             return AmiProductPricingType.HOURLY
 
     @model_validator(mode="after")
-    def check_pricing_type_alignment(cls, offer: Offer):
+    def check_pricing_type_alignment(cls, offer):
+        """
+        ensures instance types cannot have pricing set in a way that leaves
+        ambiguity on if the configuration is intended to be one of:
+
+        1. hourly
+        2. hourly + annual
+        3. hourly + monthly sub
+
+        :param Offer offer: current offer to validate
+        """
         if offer.monthly_subscription_fee is not None:
-            missing = [i.name for i in offer.instance_types if i.price_annual is None]
-            if missing:
-                error_message = f"""Offer has monthly_subscription fee but some instances are missing yearly key:
-                {'\n'.join(missing)}
-                """
-                raise ValueError(error_message)
-        elif any(i.price_annual is not None for i in offer.instance_types):
-            missing = [i.name for i in offer.instance_types if i.price_annual is None]
-            raise ValueError(
-                f"""Offer has at least one annual price but some instances are missing yearly key:
-            {'\n'.join(missing)}
-            """
-            )
+            cls._raise_on_missing_monthly_subscription_fields(offer)
+        else:
+            cls._raise_on_hourly_yearly_mismatch(offer)
         return offer
+
+    @classmethod
+    def _raise_on_missing_monthly_subscription_fields(cls, offer: Offer):
+        misconfigured = "\n".join({i.name for i in offer.instance_types if i.price_annual is not None})
+        if misconfigured:
+            error_message = f"""Offer has monthly_subscription_fee but some instances have yearly key:
+                {misconfigured}
+                """
+            raise ValueError(error_message)
+
+    @classmethod
+    def _raise_on_hourly_yearly_mismatch(cls, offer: Offer):
+        yearly_count = 0
+        hourly_count = 0
+        hourly = set()
+        yearly = set()
+        all_types = set()
+        for i in offer.instance_types:
+            all_types.add(i.name)
+            if i.price_annual is not None:
+                yearly.add(i.name)
+                yearly_count += 1
+            if i.price_hourly is not None:
+                hourly.add(i.name)
+                hourly_count += 1
+
+        if yearly_count != 0 and yearly_count < hourly_count:
+            missing = "\n".join(all_types - yearly)
+            raise ValueError(
+                f"""Offer has at least one yearly price but some instances are missing yearly key:
+                {missing}
+                """
+            )
+        elif hourly_count < yearly_count:
+            missing = "\n".join(all_types - hourly)
+            raise ValueError(
+                f"""Offer has at least one yearly price but some instances are missing yearly key:
+                {missing}
+                """
+            )
 
 
 class Region(BaseModel):

--- a/tests/test_changesets.py
+++ b/tests/test_changesets.py
@@ -444,8 +444,8 @@ def test_get_ami_listing_update_instance_type_changesets_add_new_multiple_instan
 def test_get_ami_listing_update_instance_type_changesets_add_new_instance_type_with_monthly_subscription():
     offer_config: Dict[str, Any] = {
         "instance_types": [
-            {"name": "c3.xlarge", "yearly": 123.44, "hourly": 0.12},
-            {"name": "c4.large", "yearly": 78.56, "hourly": 0.55},
+            {"name": "c3.xlarge", "yearly": None, "hourly": 0.12},
+            {"name": "c4.large", "yearly": None, "hourly": 0.55},
         ],
         "eula_document": [{"type": "StandardEula", "version": "2025-05-05"}],
         "refund_policy": "refund_policy",

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -257,6 +257,9 @@ class TestOffer:
 
     def test_monthly_subscription_fee(self):
         offer_detail = self._get_offer_details()
+        for i in offer_detail["instance_types"]:
+            del i["yearly"]
+
         offer_detail["monthly_subscription_fee"] = 50.04
 
         model = models.Offer(**offer_detail)
@@ -280,7 +283,7 @@ class TestOffer:
                 models.AmiProductPricingType.HOURLY_WITH_ANNUAL,
             ),
             (
-                [{"name": "c3.xlarge", "hourly": 0.0, "yearly": 0.0}],
+                [{"name": "c3.xlarge", "hourly": 0.0, "yearly": None}],
                 0.0,
                 models.AmiProductPricingType.HOURLY_WITH_MONTHLY_SUBSCRIPTION_FEE,
             ),
@@ -308,7 +311,6 @@ class TestOffer:
                 ],
                 None,
             ),
-            ([{"name": "c2.large", "hourly": 0.0}], 0.0),
             ([{"name": "c3.large", "hourly": 0.0}, {"name": "c3.xlarge", "hourly": 0.0, "yearly": 0.0}], 0.0),
         ],
     )
@@ -319,7 +321,7 @@ class TestOffer:
         configuration is intended to be one of:
         1. hourly
         2. hourly + annual
-        3. hourly + annual + monthly sub
+        3. hourly + monthly sub
         """
         offer_item = {
             "eula_document": [{"type": "CustomEula", "url": "https://example.com"}],


### PR DESCRIPTION
this PR solves two issues issues:

1. a offer configuration could previously have a pricing configuration that is ambiguous
2. prevent hourly pricing from being greater than annual pricing

the first case is a clear misconfiguration. the second case is very likely to be an unintentional configuration issue.