### PR TITLE
fix: correct Videos field typea in PromotionalResourcesModel

### DIFF
--- a/awsmp/models.py
+++ b/awsmp/models.py
@@ -297,7 +297,7 @@ class PromotionalResourcesModel(BaseModel):
     """
 
     LogoUrl: HttpUrl
-    Videos: List[HttpUrl]
+    Videos: List[dict[str, str]]
     AdditionalResources: YamlSupportResources
 
     @field_validator("AdditionalResources")
@@ -307,6 +307,14 @@ class PromotionalResourcesModel(BaseModel):
         # To compare values correctly, the link value from entity's AdditionalResources field also
         # needs to be converted to an HttpUrl and then back to string format.
         return [{"Text": resource["Text"], "Url": str(HttpUrl(resource["Url"]))} for resource in value]
+
+    @field_validator("Videos")
+    def videos_validator(cls, value) -> List:
+        # The Ami class takes url as HttpUrl and converts it to string format for API request.
+        # And HttpUrl adds a trailing slash to the end of a URL.
+        # To compare values correctly, the link value from entity's Videos field also
+        # needs to be converted to an HttpUrl and then back to string format.
+        return [HttpUrl(value[0]["Url"])] if value else []
 
 
 class SupportInformationModel(BaseModel):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -591,7 +591,7 @@ class TestEntity:
                 {
                     "PromotionalResources": models.PromotionalResourcesModel(
                         LogoUrl="https://test-logourl",
-                        Videos=["https://video-url"],
+                        Videos=[{"Type": "Link", "Title": "Product Video", "Url": "https://video-url"}],
                         AdditionalResources=[{"Text": "test-link", "Url": "https://test-url/"}],
                     ),
                 },
@@ -772,3 +772,35 @@ class TestEntity:
         entity1, entity2 = get_entity
         entity2.Terms[index] = custom_config
         assert entity1.get_diff(entity2) == expected_diff
+
+
+class PromotionalResourcesModelTest:
+    def test_get_promotional_resources_videos(self):
+        res = models.PromotionalResourcesModel(
+            LogoUrl=HttpUrl(
+                "https://test-logourl"
+            ),  # mypy error since it doesn't recognize the pydantic convert at runtime
+            Videos=[{"Type": "Link", "Title": "Product Video", "Url": "https://video-url"}],
+            AdditionalResources=[{"Text": "test-link", "Url": "https://test-url/"}],
+        )
+        assert res.Videos == HttpUrl("https://video-url")
+
+    def test_get_promotional_resources_videos_empty(self):
+        res = models.PromotionalResourcesModel(
+            LogoUrl=HttpUrl(
+                "https://test-logourl"
+            ),  # mypy error since it doesn't recognize the pydantic convert at runtime
+            Videos=[],
+            AdditionalResources=[{"Text": "test-link", "Url": "https://test-url/"}],
+        )
+        assert res.Videos == []
+
+    def test_get_promotional_resources_invalid_videos(self):
+        with pytest.raises(ValidationError):
+            models.PromotionalResourcesModel(
+                LogoUrl=HttpUrl(
+                    "https://test-logourl"
+                ),  # mypy error since it doesn't recognize the pydantic convert at runtime
+                Videos=["url"],  # type: ignore
+                AdditionalResources=[{"Text": "test-link", "Url": "https://test-url/"}],
+            )


### PR DESCRIPTION
The Videos has a list of dictionaries with metadata: "Videos": [
      {
        "Type": "Link",
        "Title": "Product Video",
        "Url": "https://some-url"
      }
],

Updated the pydantic model to use the
correct type and ensures only the "Url" part
is returned in the output to compare diff.