### PR TITLE
feat: add Version model to get full listing information

### DIFF
--- a/awsmp/models.py
+++ b/awsmp/models.py
@@ -464,6 +464,66 @@ class PricingTermModel(BaseModel):
     RateCards: List[RateCardItemsModel]
 
 
+class OperatingSystemModel(BaseModel):
+    """
+    Model for Operating system
+    """
+
+    Name: str
+    Version: str
+    Username: str
+    ScanningPort: int
+
+
+class SourcesModel(BaseModel):
+    """
+    Model for sources
+    """
+
+    Image: str
+    OperatingSystem: OperatingSystemModel
+
+
+class SecurityGroupsModel(BaseModel):
+    """
+    Model for security groups
+    """
+
+    Protocol: Literal["tcp", "udp"]
+    FromPort: int
+    ToPort: int
+    CidrIps: List[str]
+
+
+class RecommendationsModel(BaseModel):
+    """
+    Model for recommendations
+    """
+
+    SecurityGroups: List[SecurityGroupsModel]
+    InstanceType: str
+
+
+class DeliveryMethodsModel(BaseModel):
+    """
+    Model for delivery method
+    """
+
+    Instructions: dict[str, str]
+    Recommendations: RecommendationsModel
+
+
+class VersionModel(BaseModel):
+    """
+    Model for version from entity details
+    """
+
+    VersionTitle: str
+    ReleaseNotes: str
+    Sources: List[SourcesModel]
+    DeliveryMethods: List[DeliveryMethodsModel]
+
+
 class DiffAddedModel(BaseModel):
     """
     Model for fields that have been added in a diff comparison

--- a/tests/test_config.json
+++ b/tests/test_config.json
@@ -29,6 +29,10 @@
                 "Constraints": {"MultipleDimensionSelection": "Allowed","QuantityConfiguration": "Allowed"},
                 "RateCard": [{"DimensionKey": "a1.large","Price": "24.528"},
                     {"DimensionKey": "a1.xlarge","Price": "49.056"}]
-            }]}]
+            }]}],
+        "Versions": {"ReleaseNotes": "test release notes", 
+            "VersionTitle": "Test Ubuntu AMI", 
+            "Sources": [{"Type": "AmazonMachineImage", "Image": "ami-12345678910", "Architecture": "x86_64", "VirtualizationType": "hvm", "OperatingSystem": {"Name": "UBUNTU", "Version": "22.04 - Jammy", "Username": "ubuntu", "ScanningPort": 22}, "Compatibility": {"AvailableInstanceTypes": ["t2.nano", "t3.medium"], "RestrictedInstanceTypes": []}}], "DeliveryMethods": [{"Type": "AmazonMachineImage", "ShortDescription": "No description provided for this delivery method", "Instructions": {"Usage": "test_usage_instruction\n"}, "Recommendations": {"SecurityGroups": [{"Protocol": "tcp", "FromPort": 22, 
+                "ToPort": 22, "CidrIps": ["0.0.0.0/0"]}], "InstanceType": "t3.medium"}, "Visibility": "Public", "Title": "(x86_64) Amazon Machine Image"}], "DeliveryOptions": [{"Instructions": {"Usage": "test usage instruction\n"}, "Recommendations": {"SecurityGroups": [{"Protocol": "tcp", "FromPort": 22, "ToPort": 22, "CidrIps": ["0.0.0.0/0"]}], "InstanceType": "t3.medium"}, "Visibility": "Public", "Title": "(x86_64) Amazon Machine Image"}]}
 }
 


### PR DESCRIPTION
Currently, the Entity class does not have a VersionModel to create complete Entity object from the product listing.

Add the model so that the Entity can include at least one of the version when being created from the listing.