### PR TITLE
Support `to_dict` method in the `*Model` class

### DIFF
--- a/awsmp/models.py
+++ b/awsmp/models.py
@@ -363,6 +363,23 @@ class DescriptionModel(BaseModel):
     SearchKeywords: List[str]
     Categories: List[str]
 
+    def to_dict(self) -> dict[str, Any]:
+        """
+        Return dictionary of description information with local configuration field names
+
+        :return: Dictionary of description information
+        :rtype: dict[str, Any]
+        """
+        return {
+            "product_title": self.ProductTitle,
+            "short_description": self.ShortDescription,
+            "long_description": self.LongDescription,
+            "sku": self.Sku,
+            "highlights": self.Highlights,
+            "search_keywords": self.SearchKeywords,
+            "categories": self.Categories,
+        }
+
 
 class PromotionalResourcesModel(BaseModel):
     """
@@ -389,6 +406,23 @@ class PromotionalResourcesModel(BaseModel):
         # needs to be converted to an HttpUrl and then back to string format.
         return [HttpUrl(value[0]["Url"])] if value else []
 
+    def to_dict(self) -> dict[str, Any]:
+        """
+        Return dictionary of promotional resource information with local configuration field names
+
+        :return: Dictionary of promotional resource information
+        :rtype: dict[str, Any]
+        """
+        resources = []
+        for resource in self.AdditionalResources:
+            resources.append({resource["Text"]: resource["Url"]})
+
+        return {
+            "logo_url": str(self.LogoUrl),
+            "video_urls": [str(video) for video in self.Videos],
+            "additional_resources": resources,
+        }
+
 
 class SupportInformationModel(BaseModel):
     """
@@ -398,6 +432,15 @@ class SupportInformationModel(BaseModel):
     Description: str
     Resources: List[str]
 
+    def to_dict(self) -> dict[str, Any]:
+        """
+        Return dictionary of support information with local configuration field names.
+
+        :return: Dictionary of support information
+        :rtype: dict[str, Any]
+        """
+        return {"support_description": self.Description, "support_resources": self.Resources}
+
 
 class RegionAvailabilityModel(BaseModel):
     """
@@ -406,6 +449,16 @@ class RegionAvailabilityModel(BaseModel):
 
     Regions: List[str]
     FutureRegionSupport: str
+
+    def to_dict(self) -> dict[str, Any]:
+        """
+        Return dictionary of region availability with local configuration field names.
+
+        :return: Dictionary of region availability information
+        :rtype: dict[str, Any]
+        """
+        future_region_support = True if self.FutureRegionSupport == "All" else False
+        return {"commercial_regions": self.Regions, "future_region_support": future_region_support}
 
 
 class SupportTermModel(BaseModel):
@@ -474,6 +527,20 @@ class OperatingSystemModel(BaseModel):
     Username: str
     ScanningPort: int
 
+    def to_dict(self) -> dict[str, Any]:
+        """
+        Return dictionary of operating system with local configuration field names.
+
+        :return: Dictionary of operating system information
+        :rtype: dict[str, Any]
+        """
+        return {
+            "os_system_name": self.Name,
+            "os_user_name": self.Username,
+            "os_system_version": self.Version,
+            "scanning_port": self.ScanningPort,
+        }
+
 
 class SourcesModel(BaseModel):
     """
@@ -482,6 +549,15 @@ class SourcesModel(BaseModel):
 
     Image: str
     OperatingSystem: OperatingSystemModel
+
+    def to_dict(self) -> dict[str, Any]:
+        """
+        Return dictionary of source information with local configuration field names.
+
+        :return: Dictionary of source information
+        :rtype: dict[str, Any]
+        """
+        return {**{"ami_id": self.Image}, **self.OperatingSystem.to_dict()}
 
 
 class SecurityGroupsModel(BaseModel):
@@ -494,6 +570,20 @@ class SecurityGroupsModel(BaseModel):
     ToPort: int
     CidrIps: List[str]
 
+    def to_dict(self) -> dict[str, Any]:
+        """
+        Return dictionary of security group information with local configuration field names.
+
+        :return: Dictionary of security group information
+        :rtype: dict[str, Any]
+        """
+        return {
+            "ip_protocol": self.Protocol,
+            "ip_ranges": self.CidrIps,
+            "from_port": self.FromPort,
+            "to_port": self.ToPort,
+        }
+
 
 class RecommendationsModel(BaseModel):
     """
@@ -503,6 +593,17 @@ class RecommendationsModel(BaseModel):
     SecurityGroups: List[SecurityGroupsModel]
     InstanceType: str
 
+    def to_dict(self) -> dict[str, Any]:
+        """
+        Return dictionary of version information with local configuration field names.
+
+        Local config file only have the initial security group information of the version
+
+        :return: Dictionary of recommendation information
+        :rtype: dict[str, Any]
+        """
+        return {**{"recommended_instance_types": self.InstanceType}, **self.SecurityGroups[0].to_dict()}
+
 
 class DeliveryMethodsModel(BaseModel):
     """
@@ -511,6 +612,15 @@ class DeliveryMethodsModel(BaseModel):
 
     Instructions: dict[str, str]
     Recommendations: RecommendationsModel
+
+    def to_dict(self) -> dict[str, Any]:
+        """
+        Return dictionary of delivery method information with local configuration field names.
+
+        :return: Dictionary of version information
+        :rtype: dict[str, Any]
+        """
+        return {**{"usage_instructions": self.Instructions["Usage"]}, **self.Recommendations.to_dict()}
 
 
 class VersionModel(BaseModel):
@@ -522,6 +632,28 @@ class VersionModel(BaseModel):
     ReleaseNotes: str
     Sources: List[SourcesModel]
     DeliveryMethods: List[DeliveryMethodsModel]
+
+    def to_dict(self) -> dict[str, Any]:
+        """
+        Return dictionary of version information with local configuration field names.
+
+        Only first sources and delivery method will be returned for the version.
+
+        :return: Dictionary of version information
+        :rtype: dict[str, Any]
+        """
+        sources = self.Sources[0].to_dict()
+        delivery_methods = self.DeliveryMethods[0].to_dict()
+
+        return {
+            **{
+                "version_title": self.VersionTitle,
+                "release_notes": self.ReleaseNotes,
+                "access_role_arn": "",
+            },
+            **self.DeliveryMethods[0].to_dict(),
+            **self.Sources[0].to_dict(),
+        }
 
 
 class DiffAddedModel(BaseModel):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -465,6 +465,13 @@ class TestEntity:
         entity_model = models.EntityModel(**response_json)
         assert entity_model.Description.ProductTitle == "test"
 
+    def test_valid_response_version(self):
+        with open("./tests/test_config.json", "r") as f:
+            response_json = json.load(f)
+
+        entity_model = models.EntityModel(**response_json)
+        assert entity_model.Versions.ReleaseNotes == "test release notes"
+
     def test_valid_response_pricing_term(self):
         with open("./tests/test_config.json", "r") as f:
             response_json = json.load(f)
@@ -479,6 +486,13 @@ class TestEntity:
 
         entity_model = models.EntityModel.get_entity_from_yaml(local_config)
         assert entity_model.Description.ProductTitle == "test"
+
+    def test_yaml_to_entity_version(self, mock_boto3):
+        with open("./tests/test_config.yaml", "r") as f:
+            local_config = yaml.safe_load(f)
+
+        entity_model = models.EntityModel.get_entity_from_yaml(local_config)
+        assert entity_model.Versions.ReleaseNotes == "test_release_notes\n"
 
     def test_yaml_to_entity_term(self, mock_boto3):
         with open("./tests/test_config.yaml", "r") as f:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -849,7 +849,7 @@ class TestEntity:
         assert entity1.get_diff(entity2) == expected_diff
 
 
-class PromotionalResourcesModelTest:
+class TestPromotionalResourcesModel:
     def test_get_promotional_resources_videos(self):
         res = models.PromotionalResourcesModel(
             LogoUrl=HttpUrl(
@@ -858,7 +858,7 @@ class PromotionalResourcesModelTest:
             Videos=[{"Type": "Link", "Title": "Product Video", "Url": "https://video-url"}],
             AdditionalResources=[{"Text": "test-link", "Url": "https://test-url/"}],
         )
-        assert res.Videos == HttpUrl("https://video-url")
+        assert res.Videos[0] == HttpUrl("https://video-url")
 
     def test_get_promotional_resources_videos_empty(self):
         res = models.PromotionalResourcesModel(

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -874,6 +874,25 @@ class TestEntity:
         entity2.Terms[index] = custom_config
         assert entity1.get_diff(entity2) == expected_diff
 
+    @pytest.mark.parametrize(
+        "key, value",
+        [
+            ("refund_policy", "test_refund_policy_term\n"),
+            (
+                "instance_types",
+                [
+                    {"name": "a1.large", "hourly": "0.004", "yearly": "24.528"},
+                    {"name": "a1.xlarge", "hourly": "0.007", "yearly": "49.056"},
+                ],
+            ),
+            ("eula_document", [{"type": ""}]),
+        ],
+    )
+    def test_convert_terms_to_dict(self, mock_boto3, get_entity, key, value):
+        entity, _ = get_entity
+        yaml_config = entity._convert_terms_to_dict()
+        assert yaml_config[key] == value
+
 
 class TestPromotionalResourcesModel:
     def test_get_promotional_resources_videos(self):


### PR DESCRIPTION
This PR adds support for the `to_dict` method in each `*Model` class, as well as handling for terms information in the `Entity` class. These implementations are necessary for the upcoming `download` CLI implementation, which will allow downloading configuration information from public or limited listings from AWS Marketplace.