### PR TITLE
fix: Correct field name for logo_url

### DIFF
--- a/awsmp/models.py
+++ b/awsmp/models.py
@@ -419,7 +419,7 @@ class PromotionalResourcesModel(BaseModel):
             resources.append({resource["Text"]: resource["Url"]})
 
         return {
-            "logo_url": str(self.LogoUrl),
+            "logourl": str(self.LogoUrl),
             "video_urls": [str(video) for video in self.Videos],
             "additional_resources": resources,
         }

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -967,7 +967,7 @@ class TestPromotionalResourcesModel:
     @pytest.mark.parametrize(
         "key, value",
         [
-            ("logo_url", "https://test.logo.url/"),
+            ("logourl", "https://test.logo.url/"),
             ("video_urls", ["https://test.video.url/"]),
             ("additional_resources", [{"test": "https://resources.url/"}]),
         ],


### PR DESCRIPTION
Fix `logo_url` to `logourl` to match
the filed name used in local config yaml file.