### PR TITLE
fix: correct field name/formatting mismatches

### DIFF
--- a/awsmp/models.py
+++ b/awsmp/models.py
@@ -373,7 +373,7 @@ class DescriptionModel(BaseModel):
         """
         return {
             "product_title": self.ProductTitle,
-            "short_description": LiteralString(self.ShortDescription),
+            "short_description": self.ShortDescription,
             "long_description": LiteralString(self.LongDescription),
             "sku": self.Sku,
             "highlights": self.Highlights,

--- a/awsmp/models.py
+++ b/awsmp/models.py
@@ -603,7 +603,7 @@ class RecommendationsModel(BaseModel):
         :return: Dictionary of recommendation information
         :rtype: dict[str, Any]
         """
-        return {**{"recommended_instance_types": self.InstanceType}, **self.SecurityGroups[0].to_dict()}
+        return {**{"recommended_instance_type": self.InstanceType}, **self.SecurityGroups[0].to_dict()}
 
 
 class DeliveryMethodsModel(BaseModel):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1042,7 +1042,7 @@ class TestRecommendationsModel:
     @pytest.mark.parametrize(
         "key, value",
         [
-            ("recommended_instance_types", "t1.micro"),
+            ("recommended_instance_type", "t1.micro"),
             ("ip_protocol", "tcp"),
             ("ip_ranges", ["0.0.0.0/0"]),
             ("from_port", 22),
@@ -1062,7 +1062,7 @@ class TestDeliveryMethodsModel:
         "key, value",
         [
             ("usage_instructions", "test usage instruction"),
-            ("recommended_instance_types", "t1.micro"),
+            ("recommended_instance_type", "t1.micro"),
             ("ip_protocol", "tcp"),
             ("ip_ranges", ["0.0.0.0/0"]),
             ("from_port", 22),
@@ -1142,7 +1142,7 @@ class TestVersionModel:
             ("version_title", "Test Ubuntu AMI"),
             ("release_notes", "test release notes"),
             ("usage_instructions", "test_usage_instruction\n"),
-            ("recommended_instance_types", "t3.medium"),
+            ("recommended_instance_type", "t3.medium"),
             ("ip_protocol", "tcp"),
             ("ip_ranges", ["0.0.0.0/0"]),
             ("from_port", 22),


### PR DESCRIPTION
Some field names and formatting did not match those in the config file.
Tested and confirmed with one of the live listings from AWS Marketplace.