### PR TITLE
feat: log requested changesets

### DIFF
--- a/awsmp/_driver.py
+++ b/awsmp/_driver.py
@@ -171,6 +171,9 @@ def get_response(changeset: List[ChangeSetType], changeset_name: str) -> ChangeS
     :rtype: ChangeSetReturnType
     """
     changeset_name = changeset_name.replace(",", "_").replace("(", "").replace(")", "")
+    logger.info(
+        "Requesting changes to marketplace listing", extra={"ChangeSetName": changeset_name, "ChangeSet": changeset}
+    )
     try:
         response = get_client().start_change_set(
             Catalog="AWSMarketplace",


### PR DESCRIPTION
for better auditing we should log all changesets before submitting the request. this updates get_response to include logs for the changeset name and the specific changeset