### PR TITLE
Add `gov_regions` field as an Optional

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -912,6 +912,7 @@ def test_public_offer_product_update_instance_type_pricing_change_exception(
         ("version", "ami_id", "ami-12345678910"),
         ("description", "support_description", "test_support_description\n"),
         ("region", "commercial_regions", ["us-east-1", "us-east-2"]),
+        ("region", "gov_regions", ["us-gov-east-1", "us-gov-west-1"]),
         ("region", "future_region_support", True),
     ],
 )
@@ -924,6 +925,7 @@ def test_public_offer_product_download_product(mock_get_public_offer_id, mock_ge
 
     mock_prod_resp["Versions"]["CreationDate"] = "2025-01-01"
     mock_prod_resp["Versions"] = [mock_prod_resp["Versions"]]
+    mock_prod_resp["RegionAvailability"]["Regions"] += ["us-gov-east-1", "us-gov-west-1"]
 
     with open("./tests/test_config.json") as f:
         mock_offer_resp = {"Terms": json.load(f)["Terms"]}

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -518,7 +518,7 @@ class TestEntity:
             local_config = yaml.safe_load(f)
 
         entity_model = models.EntityModel.get_entity_from_yaml(local_config)
-        assert entity_model.Versions.ReleaseNotes == "test_release_notes\n"
+        assert entity_model.Versions.ReleaseNotes == "temp"
 
     def test_yaml_to_entity_term(self, mock_boto3):
         with open("./tests/test_config.yaml", "r") as f:
@@ -543,6 +543,18 @@ class TestEntity:
         }
         with pytest.raises(ValidationError):
             models.EntityModel(**non_valid_response)
+
+    def test_masking_unchecked_fields(self, mock_boto3):
+        with open("./tests/test_config.yaml", "r") as f:
+            local_config = yaml.safe_load(f)
+
+        if "version" in local_config["product"]:
+            local_config["product"].pop("version")
+        if "eula_document" in local_config["offer"]:
+            local_config["offer"].pop("eula_document")
+
+        entity_model = models.EntityModel.get_entity_from_yaml(local_config)
+        assert entity_model.Description.ProductTitle == "test"
 
     @pytest.mark.parametrize(
         "name, value1, value2, expected",


### PR DESCRIPTION
When downloading the config file, gov regions were included with the commercial regions which is not correct. But Marketplace API shows gov regions in `RegionAvailability` field because the listings are copied to those regions and make them enable with the UI.
    
This update separates commercial and gov regions into different fields.
    
Note: This change is non-breaking. 
- The `update-regions` stillonly updates the commercial regions since updating gov regions with API is not available.
- `download` command will show the separate region fields with commercial/gov in `.yaml` config file.
- diff` command will still combine those two fields and show the differences between live listing and local configuration file since it only compares against the entity model which the `Region` field has both of them.
