### PR TITLE
fix: remove character limit on version_title

### DIFF
--- a/awsmp/models.py
+++ b/awsmp/models.py
@@ -312,7 +312,7 @@ class Description(BaseModel):
 
 
 class AmiVersion(BaseModel):
-    version_title: str = Field(max_length=36)
+    version_title: str = Field(min_length=1)
     release_notes: str = Field(max_length=30000)
     ami_id: str = Field(max_length=21)
     access_role_arn: str = Field(max_length=150)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -129,6 +129,12 @@ class TestAmiVersion:
         with pytest.raises(ValidationError):
             models.AmiVersion(**version)
 
+    def test_invalid_version_title(self):
+        version_detail = self._get_version_details()
+        version_detail["version_title"] = ""
+        with pytest.raises(ValidationError):
+            models.AmiVersion(**version_detail)
+
 
 class TestAmiProduct:
     @pytest.fixture


### PR DESCRIPTION
The previous character limit for `version_title`
is no longer used by Marketplace but the field
cannot be empty.