### PR TITLE
Remove non-IO logic from awsmp cli

### DIFF
--- a/awsmp/_driver.py
+++ b/awsmp/_driver.py
@@ -484,3 +484,14 @@ def get_full_response(product_id: str) -> dict[str, Any]:
             key=lambda x: term_order.get(x["Type"], 3),
         )
     return listing_resp
+
+
+def diff_entity_id_vs_local(entity_id: str, local_entity: models.EntityModel):
+    """
+    Fetch live by id, compare against provided local model.
+    """
+
+    entity_from_listing = models.EntityModel(**get_full_response(entity_id))
+    diff = entity_from_listing.get_diff(local_entity)
+
+    return diff

--- a/awsmp/_driver.py
+++ b/awsmp/_driver.py
@@ -403,6 +403,41 @@ def _get_pricing_diff(product_id: str, changeset: List[ChangeSetType], allow_pri
     return diffs_hourly, diffs_annual
 
 
+def build_pricing_rows_from_offer(offer_id: str, *, free: bool = False) -> list[tuple[str, str, str]]:
+    """
+    Return [(instance_type, hourly, annual)] based on an existing offer.
+    """
+    e = get_client().describe_entity(Catalog="AWSMarketplace", EntityId=offer_id)
+    details = e["DetailsDocument"]
+
+    prices_hourly = {}
+    prices_annual = {}
+    for term in details["Terms"]:
+        if term["Type"] not in ["UsageBasedPricingTerm", "ConfigurableUpfrontPricingTerm"]:
+            continue
+        for rate_card in term["RateCards"]:
+            for d in rate_card["RateCard"]:
+                if term["Type"] == "UsageBasedPricingTerm":
+                    # hourly
+                    prices_hourly[d["DimensionKey"]] = d["Price"]
+                elif term["Type"] == "ConfigurableUpfrontPricingTerm":
+                    # annual
+                    prices_annual[d["DimensionKey"]] = d["Price"]
+                else:
+                    raise Exception(f'Unknown terms type {term["type"]}')
+
+    # both should have the same keys so calculate the symmetric difference
+    # this should never happen given that we get the data from an available offer
+    # free listing can be skipped since it doesn't have annual pricing
+    if not free:
+        if prices_hourly.keys() ^ prices_annual.keys():
+            raise Exception("instance type dimensions are not identical in hourly and annual prices")
+    else:
+        prices_annual = prices_hourly
+
+    return [(it, prices_hourly[it], prices_annual[it]) for it in sorted(prices_hourly.keys())]
+
+
 def _get_existing_instance_types(product_id: str):
     entity = get_entity_details(product_id)
     # New created product does not have existing instance types

--- a/awsmp/_driver.py
+++ b/awsmp/_driver.py
@@ -250,6 +250,18 @@ def get_entity_details(entity_id: str) -> Dict:
     return e["DetailsDocument"]
 
 
+def get_ami_product_version_summary() -> list[models.AmiProductVersionSummary]:
+    """
+    Query a list each marketplace entry with its number of versions.
+    """
+    entity_dict = list_entities("AmiProduct")
+    versions = [
+        models.AmiProductVersionSummary(entity_id, len(get_entity_versions(entity_id)), entity_dict[entity_id]["Name"])
+        for entity_id in entity_dict.keys()
+    ]
+    return versions
+
+
 def get_public_offer_id(entity_id: str):
     client = get_client()
     e = client.list_entities(

--- a/awsmp/_driver.py
+++ b/awsmp/_driver.py
@@ -227,6 +227,19 @@ def list_entities(entity_type: str) -> dict[str, dict[str, str]]:
     return entities
 
 
+def get_entities_by_visibility(entity_type: str, visibilities: tuple[models.AmiVisibility, ...]) -> list[dict]:
+    """
+    Return entity summaries for the given entity_type filtered by Marketplace Visibility.
+
+    :param str entity_type: Marketplace entity type, e.g. "Offer" or "AmiProduct"
+    :param tuple[Visibility, ...] visibilities: One or more Visibility enum values to include
+    :return: A list of entity summary dicts as returned by ListEntities
+    :rtype: list[dict]
+    """
+    entities = list_entities(entity_type)
+    return [e for e in entities.values() if not visibilities or e["Visibility"] in visibilities]
+
+
 def get_entity_details(entity_id: str) -> Dict:
     client = get_client()
     try:

--- a/awsmp/cli.py
+++ b/awsmp/cli.py
@@ -79,11 +79,7 @@ def entity_versions_count():
     """
     List each marketplace entry with it's number of versions, sorted by number of versions
     """
-    entity_dict = _driver.list_entities("AmiProduct")
-    versions = [
-        (entity_id, len(_driver.get_entity_versions(entity_id)), entity_dict[entity_id]["Name"])
-        for entity_id in entity_dict.keys()
-    ]
+    versions = _driver.get_ami_product_version_summary()
 
     for version in sorted(versions, key=lambda x: x[1]):
         print(f"{version[0]} - {version[1]} - {version[2]}")

--- a/awsmp/cli.py
+++ b/awsmp/cli.py
@@ -52,18 +52,18 @@ def inspect():
 
 @inspect.command("entity-list")
 @click.argument("entity-type", type=click.Choice(["Offer", "AmiProduct"]))
-@click.option("--filter-visibility", multiple=True, type=click.Choice(["Public", "Restricted", "Limited"]))
+@click.option("--filter-visibility", multiple=True, type=click.Choice([v.value for v in models.AmiVisibility]))
 def entity_list(entity_type, filter_visibility):
     """
     List available entities. Currently supported are entities of type "Offer"
     and "AmiProduct".
     """
-    entity_list = _driver.list_entities(entity_type)
+    entity_list = _driver.get_entities_by_visibility(entity_type, filter_visibility)
+
     t = prettytable.PrettyTable()
     t.field_names = ["entity-id", "name", "visibility", "last-changed"]
-    for _, entity in entity_list.items():
-        if not filter_visibility or entity["Visibility"] in filter_visibility:
-            t.add_row([entity["EntityId"], entity["Name"], entity["Visibility"], entity["LastModifiedDate"]])
+    t.add_rows([[e["EntityId"], e["Name"], e["Visibility"], e["LastModifiedDate"]] for e in entity_list])
+
     print(t.get_string(sortby="last-changed"))
 
 

--- a/awsmp/cli.py
+++ b/awsmp/cli.py
@@ -116,13 +116,11 @@ def entity_get_diff(entity_id: str, config: TextIO):
     :rtype None
     """
 
-    entity_from_listing = models.EntityModel(**_driver.get_full_response(entity_id))
-
     with open(config.name, "r") as f:
         yaml_config = yaml.safe_load(f)
     local_config_entity = models.EntityModel.get_entity_from_yaml(yaml_config)
 
-    diff = entity_from_listing.get_diff(local_config_entity)
+    diff = _driver.diff_entity_id_vs_local(entity_id, local_config_entity)
 
     print(repr(diff))
 
@@ -469,7 +467,7 @@ def _load_configuration(config_path: TextIO, required_fields: List[List[str]]) -
 
     with open(config_path.name, "r") as f:
         config = yaml.safe_load(f)
-        list_of_missing_keys: List[List[str]] = []
+    list_of_missing_keys: List[List[str]] = []
 
     for keys in required_fields:
         missing_keys = []

--- a/awsmp/cli.py
+++ b/awsmp/cli.py
@@ -296,26 +296,9 @@ def ami_product_instance_type_template(arch, virt):
     """
     Generate AMI product instance type template
     """
-    # Load yaml file
-    client = _driver.get_client(service_name="ec2")
-    try:
-        e = client.get_instance_types_from_instance_requirements(
-            ArchitectureTypes=[arch],
-            VirtualizationTypes=[virt],
-            InstanceRequirements={
-                "VCpuCount": {
-                    "Min": 0,
-                },
-                "MemoryMiB": {
-                    "Min": 0,
-                },
-            },
-        )
-    except ClientError:
-        logger.exception("Profile does not have EC2 service access. Check your profile role or services.")
-        raise AccessDeniedException(service_name="ec2")
 
-    available_instances = [i["InstanceType"] for i in e["InstanceTypes"]]
+    available_instances = _driver.get_available_instance_types(arch, virt)
+
     with open("instance_type.csv", "w") as f:
         csvwriter = csv.writer(f)
         for instance in available_instances:

--- a/awsmp/models.py
+++ b/awsmp/models.py
@@ -91,6 +91,12 @@ class AmiProductPricingType(Enum):
     HOURLY_WITH_MONTHLY_SUBSCRIPTION_FEE = 3
 
 
+class AmiVisibility(str, Enum):
+    Public = "Public"
+    Restricted = "Restricted"
+    Limited = "Limited"
+
+
 class Offer(BaseModel):
     """
     Offer model

--- a/awsmp/models.py
+++ b/awsmp/models.py
@@ -9,6 +9,7 @@ from typing import (
     Dict,
     List,
     Literal,
+    NamedTuple,
     Optional,
     Tuple,
     TypedDict,
@@ -89,6 +90,12 @@ class AmiProductPricingType(Enum):
     HOURLY = 1
     HOURLY_WITH_ANNUAL = 2
     HOURLY_WITH_MONTHLY_SUBSCRIPTION_FEE = 3
+
+
+class AmiProductVersionSummary(NamedTuple):
+    entity_id: str
+    version_count: int
+    name: str
 
 
 class AmiVisibility(str, Enum):


### PR DESCRIPTION
Extracted most of the remaining pieces of marketplace business logic from the cli.py entrypoints into _driver.py so they can be reused in other contexts without going through the CLI.

I'm not sure how many of these are needed/wanted so each is separated into its own commit we can remove/squash before merge if needed.

New tests for the added helpers are not included.

Passes all local tests and generates identical test warnings.

