### PR TITLE
feat: retry on transient marketplace failures

### DIFF
--- a/awsmp/_driver.py
+++ b/awsmp/_driver.py
@@ -1,8 +1,11 @@
 import csv
 import logging
+import time
+from dataclasses import dataclass
 from typing import IO, Any, Dict, List, Optional, Tuple, cast
 
 import boto3
+from botocore import errorfactory
 from botocore.exceptions import ClientError
 
 from . import changesets, models
@@ -10,6 +13,8 @@ from .errors import (
     AccessDeniedException,
     AmiPriceChangeError,
     AmiPricingModelChangeError,
+    MarketplaceResourceInUseException,
+    MarketplaceServiceQuotaExceededException,
     MissingInstanceTypeError,
     NoVersionException,
     ResourceNotFoundException,
@@ -20,37 +25,49 @@ from .types import ChangeSetReturnType, ChangeSetType
 
 logger = logging.getLogger(__name__)
 
+LOCKED_ENTITY_ERROR = "entities locked by change sets"
+OFFER_QUOTA_ERROR = "maximum service quota limit"
+RETRYABLE_ERROR_CODES = {"ServiceQuotaExceededException", "ResourceInUseException"}
+
+
+@dataclass(frozen=True)
+class RetryConfig:
+    max_retries: int = 0
+    initial_delay_seconds: int = 60
+    max_delay_seconds: int = 300
+
 
 class AmiProduct:
-    def __init__(self, product_id: str, dry_run: bool = False):
+    def __init__(self, product_id: str, dry_run: bool = False, retry_config: Optional[RetryConfig] = None):
         self.product_id: str = product_id
         self.offer_id = get_public_offer_id(product_id)
         self._dry_run = dry_run
+        self._retry_config = retry_config
 
     @staticmethod
-    def create(dry_run: bool):
+    def create(dry_run: bool, retry_config: Optional[RetryConfig] = None):
         changeset = changesets.get_ami_listing_creation_changesets()
         changeset_name = "Create new AMI Product"
 
-        return get_response(changeset, changeset_name, dry_run)
+        return get_response(changeset, changeset_name, dry_run, retry_config=retry_config)
 
     def update_legal_terms(self, eula_document: Dict[str, str]) -> ChangeSetReturnType:
         changeset = changesets.get_ami_listing_update_legal_terms_changesets(eula_document, self.offer_id)
         changeset_name = f"Product {self.product_id} legal terms update"
 
-        return get_response(changeset, changeset_name, self._dry_run)
+        return get_response(changeset, changeset_name, self._dry_run, retry_config=self._retry_config)
 
     def update_support_terms(self, refund_policy: str) -> ChangeSetReturnType:
         changeset = changesets.get_ami_listing_update_support_terms_changesets(self.offer_id, refund_policy)
         changeset_name = f"Product {self.product_id} support terms update"
 
-        return get_response(changeset, changeset_name, self._dry_run)
+        return get_response(changeset, changeset_name, self._dry_run, retry_config=self._retry_config)
 
     def update_description(self, desc: Dict) -> ChangeSetReturnType:
         changeset = changesets.get_ami_listing_update_description_changesets(self.product_id, desc)
         changeset_name = f"Product {self.product_id} description update"
 
-        return get_response(changeset, changeset_name, self._dry_run)
+        return get_response(changeset, changeset_name, self._dry_run, retry_config=self._retry_config)
 
     def update_instance_types(
         self, offer_config: Dict[str, Any], price_change_allowed: bool
@@ -71,25 +88,25 @@ class AmiProduct:
         if changeset is None:
             return None
 
-        return get_response(changeset, changeset_name, self._dry_run)
+        return get_response(changeset, changeset_name, self._dry_run, retry_config=self._retry_config)
 
     def update_regions(self, region_config: Dict) -> ChangeSetReturnType:
         changeset = changesets.get_ami_listing_update_region_changesets(self.product_id, region_config)
         changeset_name = f"Product {self.product_id} region update"
 
-        return get_response(changeset, changeset_name, self._dry_run)
+        return get_response(changeset, changeset_name, self._dry_run, retry_config=self._retry_config)
 
     def update_version(self, version_config: Dict) -> ChangeSetReturnType:
         changeset = changesets.get_ami_listing_update_version_changesets(self.product_id, version_config)
         changeset_name = f"Product {self.product_id} version update"
 
-        return get_response(changeset, changeset_name, self._dry_run)
+        return get_response(changeset, changeset_name, self._dry_run, retry_config=self._retry_config)
 
     def release(self) -> ChangeSetReturnType:
         changeset = changesets.get_ami_release_changesets(self.product_id, self.offer_id)
         changeset_name = f"Product {self.product_id} publish as limited"
 
-        return get_response(changeset, changeset_name, self._dry_run)
+        return get_response(changeset, changeset_name, self._dry_run, retry_config=self._retry_config)
 
     def update(self, configs: Dict[str, Any], price_change_allowed: bool) -> Optional[ChangeSetReturnType]:
         """
@@ -120,7 +137,7 @@ class AmiProduct:
 
         changeset_name = f"Product {self.product_id} update product details"
 
-        return get_response(changeset, changeset_name, self._dry_run)
+        return get_response(changeset, changeset_name, self._dry_run, retry_config=self._retry_config)
 
     def _get_product_title(self):
         return get_entity_details(self.product_id)["Description"]["ProductTitle"]
@@ -160,7 +177,44 @@ def get_client(service_name="marketplace-catalog", region_name="us-east-1"):
     return boto3.client(service_name, region_name=region_name)
 
 
-def get_response(changeset: List[ChangeSetType], changeset_name: str, dry_run: bool = False) -> ChangeSetReturnType:
+def _get_retryable_changeset_exception_types(client) -> Tuple[type[Exception], ...]:
+    # These service-specific exception classes are generated under botocore.errorfactory.
+    candidate_names = ("ServiceQuotaExceededException", "ResourceInUseException")
+    retryable_exception_types: list[type[Exception]] = []
+    for name in candidate_names:
+        exception_type = getattr(client.exceptions, name, None)
+        if isinstance(exception_type, type):
+            retryable_exception_types.append(cast(type[Exception], exception_type))
+    return tuple(retryable_exception_types)
+
+
+def _is_retryable_changeset_error(
+    exception: ClientError,
+    retryable_changeset_exception_types: Tuple[type[Exception], ...],
+) -> bool:
+    if retryable_changeset_exception_types and isinstance(exception, retryable_changeset_exception_types):
+        return True
+
+    exception_code = exception.response["Error"].get("Code", "")
+    error_msg = exception.response["Error"].get("Message", "").lower()
+
+    if exception_code in RETRYABLE_ERROR_CODES:
+        return True
+
+    return LOCKED_ENTITY_ERROR in error_msg or OFFER_QUOTA_ERROR in error_msg
+
+
+def _get_retry_delay_seconds(retry_config: RetryConfig, current_retry: int) -> int:
+    delay_seconds = retry_config.initial_delay_seconds * (2**current_retry)
+    return min(delay_seconds, retry_config.max_delay_seconds)
+
+
+def get_response(
+    changeset: List[ChangeSetType],
+    changeset_name: str,
+    dry_run: bool = False,
+    retry_config: Optional[RetryConfig] = None,
+) -> ChangeSetReturnType:
     """
     Request to AWS and get response of either success of failure
 
@@ -180,16 +234,47 @@ def get_response(changeset: List[ChangeSetType], changeset_name: str, dry_run: b
             "ChangeSetArn": "DRY_RUN",
             "ChangeSetId": "DRY_RUN",
         }
-    try:
-        response = get_client().start_change_set(
-            Catalog="AWSMarketplace",
-            ChangeSet=changeset,
-            ChangeSetName=changeset_name,
-        )
-    except ClientError as e:
-        _raise_client_error(e)
 
-    return response
+    retry_config = retry_config or RetryConfig()
+    client = get_client()
+    retryable_changeset_exception_types = _get_retryable_changeset_exception_types(client)
+
+    # Validate that generated exception classes map to botocore.errorfactory.
+    for retry_exception in retryable_changeset_exception_types:
+        if retry_exception.__module__ != errorfactory.__name__:
+            logger.debug("Unexpected retry exception module", extra={"module": retry_exception.__module__})
+
+    current_retry = 0
+    while True:
+        try:
+            return client.start_change_set(
+                Catalog="AWSMarketplace",
+                ChangeSet=changeset,
+                ChangeSetName=changeset_name,
+            )
+        except ClientError as error:
+            if not _is_retryable_changeset_error(error, retryable_changeset_exception_types):
+                _raise_client_error(error)
+
+            if current_retry >= retry_config.max_retries:
+                logger.exception(
+                    "Retries exhausted for transient Marketplace contention error.",
+                    extra={"max_retries": retry_config.max_retries},
+                )
+                _raise_client_error(error)
+
+            delay_seconds = _get_retry_delay_seconds(retry_config, current_retry)
+            current_retry += 1
+            logger.warning(
+                "Retrying failed Marketplace start_change_set request",
+                extra={
+                    "attempt": current_retry,
+                    "max_retries": retry_config.max_retries,
+                    "wait_seconds": delay_seconds,
+                    "error_code": error.response["Error"].get("Code", ""),
+                },
+            )
+            time.sleep(delay_seconds)
 
 
 def _raise_client_error(exception: ClientError):
@@ -206,6 +291,12 @@ def _raise_client_error(exception: ClientError):
     elif exception_code == "ValidationException":
         logger.exception(f"Please check schema regex and request with fixed value.")
         raise ValidationException(error_msg) from None
+    elif exception_code == "ServiceQuotaExceededException" or OFFER_QUOTA_ERROR in error_msg.lower():
+        logger.exception(error_msg)
+        raise MarketplaceServiceQuotaExceededException(error_msg) from None
+    elif exception_code == "ResourceInUseException" or LOCKED_ENTITY_ERROR in error_msg.lower():
+        logger.exception(error_msg)
+        raise MarketplaceResourceInUseException(error_msg) from None
     else:
         logger.exception(error_msg)
         raise Exception
@@ -502,6 +593,7 @@ def offer_create(
     pricing: IO,
     dry_run: bool,
     hourly: bool = False,
+    retry_config: Optional[RetryConfig] = None,
 ) -> ChangeSetReturnType:
     csvreader = csv.DictReader(pricing, fieldnames=["name", "price_hourly", "price_annual"])
     instance_type_pricing = [models.InstanceTypePricing(**line) for line in csvreader]  # type:ignore
@@ -529,7 +621,7 @@ def offer_create(
 
     changeset_name = f'{f"create private offer for {product_id}: {offer_name}"[:95]}...'
 
-    return get_response(changeset_list, changeset_name, dry_run)
+    return get_response(changeset_list, changeset_name, dry_run, retry_config=retry_config)
 
 
 def create_offer_name(product_id: str, buyer_accounts: List[str], with_support: bool, customer_name: str) -> str:

--- a/awsmp/cli.py
+++ b/awsmp/cli.py
@@ -21,6 +21,18 @@ from .errors import (
 logger = logging.getLogger(__name__)
 
 
+def _build_retry_config(
+    retry_max_retries: int,
+    retry_initial_delay_seconds: int,
+    retry_max_delay_seconds: int,
+) -> _driver.RetryConfig:
+    return _driver.RetryConfig(
+        max_retries=retry_max_retries,
+        initial_delay_seconds=retry_initial_delay_seconds,
+        max_delay_seconds=retry_max_delay_seconds,
+    )
+
+
 @click.group()
 def cli():
     pass
@@ -139,6 +151,9 @@ def entity_get_diff(entity_id: str, config: TextIO):
 @click.option("--pricing", type=click.File("r"), required=True, prompt=True)
 @click.option("--dry-run/--no-dry-run", is_flag=True)
 @click.option("--hourly", is_flag=True, help="Create hourly listing")
+@click.option("--retry-max-retries", default=0, show_default=True, type=click.IntRange(min=0))
+@click.option("--retry-initial-delay-seconds", default=60, show_default=True, type=click.IntRange(min=1))
+@click.option("--retry-max-delay-seconds", default=300, show_default=True, type=click.IntRange(min=1))
 def offer_create(
     product_id,
     buyer_accounts,
@@ -150,6 +165,9 @@ def offer_create(
     pricing,
     dry_run,
     hourly=False,
+    retry_max_retries=0,
+    retry_initial_delay_seconds=60,
+    retry_max_delay_seconds=300,
 ):
     """
     Create a new private offer.
@@ -191,6 +209,11 @@ def offer_create(
         pricing,
         dry_run,
         hourly=hourly,
+        retry_config=_build_retry_config(
+            retry_max_retries,
+            retry_initial_delay_seconds,
+            retry_max_delay_seconds,
+        ),
     )
 
     print(f'ChangeSet created (ID: {response["ChangeSetId"]})')
@@ -215,11 +238,21 @@ def offer_pricing_template(offer_id, pricing, free):
 
 @public_offer.command("create")
 @click.option("--dry-run/--no-dry-run", is_flag=True)
-def ami_product_create(dry_run):
+@click.option("--retry-max-retries", default=0, show_default=True, type=click.IntRange(min=0))
+@click.option("--retry-initial-delay-seconds", default=60, show_default=True, type=click.IntRange(min=1))
+@click.option("--retry-max-delay-seconds", default=300, show_default=True, type=click.IntRange(min=1))
+def ami_product_create(dry_run, retry_max_retries, retry_initial_delay_seconds, retry_max_delay_seconds):
     """
     Create a new AMI product listing
     """
-    response = _driver.AmiProduct.create(dry_run=dry_run)
+    response = _driver.AmiProduct.create(
+        dry_run=dry_run,
+        retry_config=_build_retry_config(
+            retry_max_retries,
+            retry_initial_delay_seconds,
+            retry_max_delay_seconds,
+        ),
+    )
 
     print(f'ChangeSet created (ID: {response["ChangeSetId"]})')
     print(f'https://aws.amazon.com/marketplace/management/requests/{response["ChangeSetId"]}')
@@ -229,13 +262,31 @@ def ami_product_create(dry_run):
 @click.option("--product-id", required=True, prompt=True)
 @click.option("--config", type=click.File("r"), required=True, prompt=True)
 @click.option("--dry-run/--no-dry-run", is_flag=True)
-def ami_product_update_description(product_id, config, dry_run):
+@click.option("--retry-max-retries", default=0, show_default=True, type=click.IntRange(min=0))
+@click.option("--retry-initial-delay-seconds", default=60, show_default=True, type=click.IntRange(min=1))
+@click.option("--retry-max-delay-seconds", default=300, show_default=True, type=click.IntRange(min=1))
+def ami_product_update_description(
+    product_id,
+    config,
+    dry_run,
+    retry_max_retries,
+    retry_initial_delay_seconds,
+    retry_max_delay_seconds,
+):
     """
     Update AMI product description
     """
     # Load yaml file
     desc = _load_configuration(config, [["product", "description"]])["product"]["description"]
-    response = _driver.AmiProduct(product_id=product_id, dry_run=dry_run).update_description(desc)
+    response = _driver.AmiProduct(
+        product_id=product_id,
+        dry_run=dry_run,
+        retry_config=_build_retry_config(
+            retry_max_retries,
+            retry_initial_delay_seconds,
+            retry_max_delay_seconds,
+        ),
+    ).update_description(desc)
     print(f'ChangeSet created (ID: {response["ChangeSetId"]})')
     print(f'https://aws.amazon.com/marketplace/management/requests/{response["ChangeSetId"]}')
 
@@ -252,7 +303,18 @@ def ami_product_update_description(product_id, config, dry_run):
     prompt="Is price update allowed? (y). Default is False.",
 )
 @click.option("--dry-run/--no-dry-run", is_flag=True)
-def ami_product_update_instance_type(product_id: str, config: TextIO, allow_price_change: bool, dry_run: bool) -> None:
+@click.option("--retry-max-retries", default=0, show_default=True, type=click.IntRange(min=0))
+@click.option("--retry-initial-delay-seconds", default=60, show_default=True, type=click.IntRange(min=1))
+@click.option("--retry-max-delay-seconds", default=300, show_default=True, type=click.IntRange(min=1))
+def ami_product_update_instance_type(
+    product_id: str,
+    config: TextIO,
+    allow_price_change: bool,
+    dry_run: bool,
+    retry_max_retries: int,
+    retry_initial_delay_seconds: int,
+    retry_max_delay_seconds: int,
+) -> None:
     """
     Update AMI product instance type
     :param str product_id: Id of listing
@@ -261,7 +323,15 @@ def ami_product_update_instance_type(product_id: str, config: TextIO, allow_pric
     :return: None
     :rtype: None
     """
-    product = _driver.AmiProduct(product_id=product_id, dry_run=dry_run)
+    product = _driver.AmiProduct(
+        product_id=product_id,
+        dry_run=dry_run,
+        retry_config=_build_retry_config(
+            retry_max_retries,
+            retry_initial_delay_seconds,
+            retry_max_delay_seconds,
+        ),
+    )
     offer_config = _load_configuration(config, [["offer"]])["offer"]
     response = product.update_instance_types(offer_config, allow_price_change)
     if response:
@@ -290,14 +360,32 @@ def ami_product_instance_type_template(arch, virt):
 @click.option("--product-id", required=True, prompt=True)
 @click.option("--config", type=click.File("r"), required=True, prompt=True)
 @click.option("--dry-run/--no-dry-run", is_flag=True)
-def ami_product_update_regions(product_id, config, dry_run):
+@click.option("--retry-max-retries", default=0, show_default=True, type=click.IntRange(min=0))
+@click.option("--retry-initial-delay-seconds", default=60, show_default=True, type=click.IntRange(min=1))
+@click.option("--retry-max-delay-seconds", default=300, show_default=True, type=click.IntRange(min=1))
+def ami_product_update_regions(
+    product_id,
+    config,
+    dry_run,
+    retry_max_retries,
+    retry_initial_delay_seconds,
+    retry_max_delay_seconds,
+):
     """
     Update AMI product region
     """
     # Load yaml file
     region_config = _load_configuration(config, [["product", "region"]])["product"]["region"]
 
-    product = _driver.AmiProduct(product_id=product_id, dry_run=dry_run)
+    product = _driver.AmiProduct(
+        product_id=product_id,
+        dry_run=dry_run,
+        retry_config=_build_retry_config(
+            retry_max_retries,
+            retry_initial_delay_seconds,
+            retry_max_delay_seconds,
+        ),
+    )
     response = product.update_regions(region_config)
     print(f'ChangeSet created (ID: {response["ChangeSetId"]})')
     print(f'https://aws.amazon.com/marketplace/management/requests/{response["ChangeSetId"]}')
@@ -307,14 +395,32 @@ def ami_product_update_regions(product_id, config, dry_run):
 @click.option("--product-id", required=True, prompt=True)
 @click.option("--config", type=click.File("r"), required=True, prompt=True)
 @click.option("--dry-run/--no-dry-run", is_flag=True)
-def ami_product_update_version(product_id, config, dry_run):
+@click.option("--retry-max-retries", default=0, show_default=True, type=click.IntRange(min=0))
+@click.option("--retry-initial-delay-seconds", default=60, show_default=True, type=click.IntRange(min=1))
+@click.option("--retry-max-delay-seconds", default=300, show_default=True, type=click.IntRange(min=1))
+def ami_product_update_version(
+    product_id,
+    config,
+    dry_run,
+    retry_max_retries,
+    retry_initial_delay_seconds,
+    retry_max_delay_seconds,
+):
     """
     Update AMI product version
     """
     # Load yaml file
     version_config = _load_configuration(config, [["product", "version"]])["product"]["version"]
 
-    product = _driver.AmiProduct(product_id=product_id, dry_run=dry_run)
+    product = _driver.AmiProduct(
+        product_id=product_id,
+        dry_run=dry_run,
+        retry_config=_build_retry_config(
+            retry_max_retries,
+            retry_initial_delay_seconds,
+            retry_max_delay_seconds,
+        ),
+    )
     response = product.update_version(version_config)
     print(f'ChangeSet created (ID: {response["ChangeSetId"]})')
     print(f'https://aws.amazon.com/marketplace/management/requests/{response["ChangeSetId"]}')
@@ -324,14 +430,32 @@ def ami_product_update_version(product_id, config, dry_run):
 @click.option("--product-id", required=True, prompt=True)
 @click.option("--config", type=click.File("r"), required=True, prompt=True)
 @click.option("--dry-run/--no-dry-run", is_flag=True)
-def ami_product_update_legal_terms(product_id, config, dry_run):
+@click.option("--retry-max-retries", default=0, show_default=True, type=click.IntRange(min=0))
+@click.option("--retry-initial-delay-seconds", default=60, show_default=True, type=click.IntRange(min=1))
+@click.option("--retry-max-delay-seconds", default=300, show_default=True, type=click.IntRange(min=1))
+def ami_product_update_legal_terms(
+    product_id,
+    config,
+    dry_run,
+    retry_max_retries,
+    retry_initial_delay_seconds,
+    retry_max_delay_seconds,
+):
     """
     Update AMI product legal terms
     """
     # Load yaml file
     eula_url = _load_configuration(config, [["offer", "eula_document"]])["offer"]["eula_document"][0]
 
-    product = _driver.AmiProduct(product_id=product_id, dry_run=dry_run)
+    product = _driver.AmiProduct(
+        product_id=product_id,
+        dry_run=dry_run,
+        retry_config=_build_retry_config(
+            retry_max_retries,
+            retry_initial_delay_seconds,
+            retry_max_delay_seconds,
+        ),
+    )
     response = product.update_legal_terms(eula_url)
     print(f'ChangeSet created (ID: {response["ChangeSetId"]})')
     print(f'https://aws.amazon.com/marketplace/management/requests/{response["ChangeSetId"]}')
@@ -341,14 +465,32 @@ def ami_product_update_legal_terms(product_id, config, dry_run):
 @click.option("--product-id", required=True, prompt=True)
 @click.option("--config", type=click.File("r"), required=True, prompt=True)
 @click.option("--dry-run/--no-dry-run", is_flag=True)
-def ami_product_update_support_terms(product_id, config, dry_run):
+@click.option("--retry-max-retries", default=0, show_default=True, type=click.IntRange(min=0))
+@click.option("--retry-initial-delay-seconds", default=60, show_default=True, type=click.IntRange(min=1))
+@click.option("--retry-max-delay-seconds", default=300, show_default=True, type=click.IntRange(min=1))
+def ami_product_update_support_terms(
+    product_id,
+    config,
+    dry_run,
+    retry_max_retries,
+    retry_initial_delay_seconds,
+    retry_max_delay_seconds,
+):
     """
     Update AMI product support terms
     """
     # Load yaml file
     refund_policy = _load_configuration(config, [["offer", "refund_policy"]])["offer"]["refund_policy"]
 
-    product = _driver.AmiProduct(product_id=product_id, dry_run=dry_run)
+    product = _driver.AmiProduct(
+        product_id=product_id,
+        dry_run=dry_run,
+        retry_config=_build_retry_config(
+            retry_max_retries,
+            retry_initial_delay_seconds,
+            retry_max_delay_seconds,
+        ),
+    )
     response = product.update_support_terms(refund_policy)
     print(f'ChangeSet created (ID: {response["ChangeSetId"]})')
     print(f'https://aws.amazon.com/marketplace/management/requests/{response["ChangeSetId"]}')
@@ -357,12 +499,29 @@ def ami_product_update_support_terms(product_id, config, dry_run):
 @public_offer.command("release")
 @click.option("--product-id", required=True, prompt=True)
 @click.option("--dry-run/--no-dry-run", is_flag=True)
-def ami_product_release(product_id, dry_run):
+@click.option("--retry-max-retries", default=0, show_default=True, type=click.IntRange(min=0))
+@click.option("--retry-initial-delay-seconds", default=60, show_default=True, type=click.IntRange(min=1))
+@click.option("--retry-max-delay-seconds", default=300, show_default=True, type=click.IntRange(min=1))
+def ami_product_release(
+    product_id,
+    dry_run,
+    retry_max_retries,
+    retry_initial_delay_seconds,
+    retry_max_delay_seconds,
+):
     """
     Publish AMI product as Limited
     """
 
-    product = _driver.AmiProduct(product_id=product_id, dry_run=dry_run)
+    product = _driver.AmiProduct(
+        product_id=product_id,
+        dry_run=dry_run,
+        retry_config=_build_retry_config(
+            retry_max_retries,
+            retry_initial_delay_seconds,
+            retry_max_delay_seconds,
+        ),
+    )
     response = product.release()
     print(f'ChangeSet created (ID: {response["ChangeSetId"]})')
     print(f'https://aws.amazon.com/marketplace/management/requests/{response["ChangeSetId"]}')
@@ -379,7 +538,18 @@ def ami_product_release(product_id, dry_run):
     prompt="Is price update allowed? (y/N). Default is False.",
 )
 @click.option("--dry-run/--no-dry-run", is_flag=True)
-def ami_product_update(product_id: str, config: TextIO, allow_price_change: bool, dry_run) -> None:
+@click.option("--retry-max-retries", default=0, show_default=True, type=click.IntRange(min=0))
+@click.option("--retry-initial-delay-seconds", default=60, show_default=True, type=click.IntRange(min=1))
+@click.option("--retry-max-delay-seconds", default=300, show_default=True, type=click.IntRange(min=1))
+def ami_product_update(
+    product_id: str,
+    config: TextIO,
+    allow_price_change: bool,
+    dry_run,
+    retry_max_retries,
+    retry_initial_delay_seconds,
+    retry_max_delay_seconds,
+) -> None:
     """
     Update AMI product details (description, region, instnance type and pricing) in a single call
     :param str product_id: Id of listing
@@ -391,7 +561,15 @@ def ami_product_update(product_id: str, config: TextIO, allow_price_change: bool
 
     # Load yaml file
     configs = _load_configuration(config, [["product", "description"], ["product", "region"], ["offer"]])
-    product = _driver.AmiProduct(product_id=product_id, dry_run=dry_run)
+    product = _driver.AmiProduct(
+        product_id=product_id,
+        dry_run=dry_run,
+        retry_config=_build_retry_config(
+            retry_max_retries,
+            retry_initial_delay_seconds,
+            retry_max_delay_seconds,
+        ),
+    )
     response = product.update(configs, allow_price_change)
 
     if response:

--- a/awsmp/errors.py
+++ b/awsmp/errors.py
@@ -59,6 +59,29 @@ Please check schema regex and request with fixed value.
         super().__init__(message)
 
 
+class MarketplaceServiceQuotaExceededException(AWSException):
+    def __init__(self, error_msg: str):
+        message = f"""
+
+
+{error_msg}
+Please wait and retry after existing in-flight updates complete.
+"""
+        super().__init__(message)
+
+
+class MarketplaceResourceInUseException(AWSException):
+    def __init__(self, error_msg: str):
+        message = f"""
+
+
+{error_msg}
+Requested entities are currently locked by another in-flight change set.
+Please wait and retry.
+"""
+        super().__init__(message)
+
+
 class YamlMissingKeyException(Exception):
     def __init__(self, missing_keys: List[List[str]]):
         formatted_keys = "\n".join("->".join(keys) for keys in missing_keys)

--- a/docs/private-offer/index.rst
+++ b/docs/private-offer/index.rst
@@ -1,6 +1,34 @@
 How to create a private offer
 =============================
 
+Retry behaviour for change-set workflows
+----------------------------------------
+
+Commands that submit Marketplace change sets now support retry options for transient contention failures.
+
+Retry flags:
+
+- ``--retry-max-retries`` (default: ``0``; retries are opt-in)
+- ``--retry-initial-delay-seconds`` (default: ``60``)
+- ``--retry-max-delay-seconds`` (default: ``300``)
+
+Supported private-offer workflow:
+
+- ``awsmp private-offer create``
+
+Example:
+
+.. code-block:: sh
+
+   awsmp private-offer create \
+      --product-id 3a628887-30de-4d23-a949-93b32e4e4c5f \
+      --buyer-accounts 887450378614 \
+      --customer-name "toabctl testing" \
+      --pricing prices.csv \
+      --retry-max-retries 3 \
+      --retry-initial-delay-seconds 60 \
+      --retry-max-delay-seconds 300
+
 To create a private offer in the `AWS marketplace management portal`_, use the API calls described below.
 
 

--- a/docs/public-offer/index.rst
+++ b/docs/public-offer/index.rst
@@ -1,6 +1,43 @@
 How to create a public offer
 ============================
 
+Retry behaviour for change-set workflows
+----------------------------------------
+
+Commands that submit Marketplace change sets now support retry options for transient contention failures such as:
+
+- ``Requested change set has entities locked by change sets``
+- ``maximum service quota limit ... entities ... updated concurrently``
+
+Retry flags:
+
+- ``--retry-max-retries`` (default: ``0``; retries are opt-in)
+- ``--retry-initial-delay-seconds`` (default: ``60``)
+- ``--retry-max-delay-seconds`` (default: ``300``)
+
+Supported public-offer workflows:
+
+- ``awsmp public-offer create``
+- ``awsmp public-offer update-description``
+- ``awsmp public-offer update-instance-type``
+- ``awsmp public-offer update-region``
+- ``awsmp public-offer update-version``
+- ``awsmp public-offer update-legal-terms``
+- ``awsmp public-offer update-support-terms``
+- ``awsmp public-offer release``
+- ``awsmp public-offer update``
+
+Example:
+
+.. code-block:: sh
+
+   awsmp public-offer update \
+      --product-id prod-fwu3xsqup23cs \
+      --config listing_configuration.yaml \
+      --retry-max-retries 3 \
+      --retry-initial-delay-seconds 60 \
+      --retry-max-delay-seconds 300
+
 To create a new public AMI product listing in the `AWS marketplace management portal`_, use the API calls described below:
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -86,6 +86,49 @@ def test_offer_create(mock_get_client, mock_get_entity_details):
     } == mock_start_change_set.call_args_list[0].kwargs["ChangeSet"][3]["DetailsDocument"]["Terms"][0]["RateCards"][0]
 
 
+@patch("awsmp._driver.create_offer_name")
+@patch("awsmp._driver.offer_create")
+def test_private_offer_create_passes_retry_options(mock_offer_create, mock_create_offer_name):
+    mock_create_offer_name.return_value = "some-offer-name"
+    mock_offer_create.return_value = {"ChangeSetId": "test-id"}
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli.offer_create,
+        [
+            "--product-id",
+            "some-product-id",
+            "--buyer-accounts",
+            "123456789012",
+            "--available-for-days",
+            "14",
+            "--valid-for-days",
+            "365",
+            "--with-support",
+            "--customer-name",
+            "some-customer",
+            "--eula-url",
+            "",
+            "--pricing",
+            "./tests/prices.csv",
+            "--retry-max-retries",
+            "3",
+            "--retry-initial-delay-seconds",
+            "7",
+            "--retry-max-delay-seconds",
+            "11",
+        ],
+        input="y\n",
+    )
+
+    assert result.exit_code == 0
+    assert mock_offer_create.call_args.kwargs["retry_config"] == _driver.RetryConfig(
+        max_retries=3,
+        initial_delay_seconds=7,
+        max_delay_seconds=11,
+    )
+
+
 def test_ami_product_instance_type_template():
     """
     Test with invalid architecture argument
@@ -94,6 +137,36 @@ def test_ami_product_instance_type_template():
     result = runner.invoke(cli.ami_product_instance_type_template, ["--arch", "invalid", "--virt", "hvm"])
     # click exceptions get translated to SystemEixt unless specified
     assert isinstance(result.exception, SystemExit)
+
+
+@patch("awsmp._driver.AmiProduct")
+def test_public_offer_update_passes_retry_options(mock_ami_product):
+    mock_ami_product.return_value.update.return_value = {"ChangeSetId": "test-id"}
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli.ami_product_update,
+        [
+            "--product-id",
+            "some-prod-id",
+            "--config",
+            "./tests/test_config.yaml",
+            "--no-allow-price-change",
+            "--retry-max-retries",
+            "4",
+            "--retry-initial-delay-seconds",
+            "9",
+            "--retry-max-delay-seconds",
+            "21",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert mock_ami_product.call_args.kwargs["retry_config"] == _driver.RetryConfig(
+        max_retries=4,
+        initial_delay_seconds=9,
+        max_delay_seconds=21,
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -14,6 +14,8 @@ from awsmp.errors import (
     AccessDeniedException,
     AmiPriceChangeError,
     AmiPricingModelChangeError,
+    MarketplaceResourceInUseException,
+    MarketplaceServiceQuotaExceededException,
     MissingInstanceTypeError,
     NoVersionException,
     ResourceNotFoundException,
@@ -37,6 +39,10 @@ DRY_RUN_RESPONSE = {
     "ChangeSetArn": "DRY_RUN",
     "ChangeSetId": "DRY_RUN",
 }
+
+
+def _build_client_error(code: str, message: str) -> ClientError:
+    return ClientError({"Error": {"Code": code, "Message": message}}, "StartChangeSet")
 
 
 @pytest.mark.parametrize(
@@ -177,6 +183,113 @@ def test_ami_product_create_dry_run(mock_get_client):
     response = _driver.AmiProduct.create(dry_run=True)
     mock_get_client.return_value.start_change_set.assert_not_called()
     assert response == DRY_RUN_RESPONSE
+
+
+@patch("awsmp._driver.time.sleep")
+@patch("awsmp._driver.get_client")
+def test_get_response_retries_service_quota_exceeded(mock_get_client, mock_sleep):
+    class ServiceQuotaExceededException(ClientError):
+        pass
+
+    class ResourceInUseException(ClientError):
+        pass
+
+    ServiceQuotaExceededException.__module__ = "botocore.errorfactory"
+    ResourceInUseException.__module__ = "botocore.errorfactory"
+
+    mock_get_client.return_value.exceptions.ServiceQuotaExceededException = ServiceQuotaExceededException
+    mock_get_client.return_value.exceptions.ResourceInUseException = ResourceInUseException
+
+    mock_get_client.return_value.start_change_set.side_effect = [
+        ServiceQuotaExceededException(
+            {
+                "Error": {
+                    "Code": "ServiceQuotaExceededException",
+                    "Message": "You have reached the maximum service quota limit of 20 total entities that can be updated concurrently for Offer entity type for your account.",
+                }
+            },
+            "StartChangeSet",
+        ),
+        {"ChangeSetId": "ok", "ChangeSetArn": "arn:ok"},
+    ]
+
+    response = _driver.get_response(
+        changeset=[cast(ChangeSetType, {"ChangeType": "UpdateInformation"})],
+        changeset_name="test",
+        dry_run=False,
+        retry_config=_driver.RetryConfig(max_retries=2, initial_delay_seconds=60, max_delay_seconds=300),
+    )
+
+    assert response["ChangeSetId"] == "ok"
+    assert mock_get_client.return_value.start_change_set.call_count == 2
+    mock_sleep.assert_called_once_with(60)
+
+
+@patch("awsmp._driver.time.sleep")
+@patch("awsmp._driver.get_client")
+def test_get_response_retries_exhausted_for_resource_in_use(mock_get_client, mock_sleep):
+    class ServiceQuotaExceededException(ClientError):
+        pass
+
+    class ResourceInUseException(ClientError):
+        pass
+
+    ServiceQuotaExceededException.__module__ = "botocore.errorfactory"
+    ResourceInUseException.__module__ = "botocore.errorfactory"
+
+    mock_get_client.return_value.exceptions.ServiceQuotaExceededException = ServiceQuotaExceededException
+    mock_get_client.return_value.exceptions.ResourceInUseException = ResourceInUseException
+
+    mock_get_client.return_value.start_change_set.side_effect = [
+        ResourceInUseException(
+            {
+                "Error": {
+                    "Code": "ResourceInUseException",
+                    "Message": "Requested change set has entities locked by change sets - entity .",
+                }
+            },
+            "StartChangeSet",
+        ),
+        ResourceInUseException(
+            {
+                "Error": {
+                    "Code": "ResourceInUseException",
+                    "Message": "Requested change set has entities locked by change sets - entity .",
+                }
+            },
+            "StartChangeSet",
+        ),
+        ResourceInUseException(
+            {
+                "Error": {
+                    "Code": "ResourceInUseException",
+                    "Message": "Requested change set has entities locked by change sets - entity .",
+                }
+            },
+            "StartChangeSet",
+        ),
+    ]
+
+    with pytest.raises(MarketplaceResourceInUseException):
+        _driver.get_response(
+            changeset=[cast(ChangeSetType, {"ChangeType": "UpdateInformation"})],
+            changeset_name="test",
+            dry_run=False,
+            retry_config=_driver.RetryConfig(max_retries=2, initial_delay_seconds=1, max_delay_seconds=5),
+        )
+
+    assert mock_get_client.return_value.start_change_set.call_count == 3
+    assert [args[0] for args, _ in mock_sleep.call_args_list] == [1, 2]
+
+
+def test_raise_client_error_quota_message_maps_to_typed_exception():
+    with pytest.raises(MarketplaceServiceQuotaExceededException):
+        _driver._raise_client_error(
+            _build_client_error(
+                "InternalFailure",
+                "You have reached the maximum service quota limit of 20 total entities that can be updated concurrently for Offer entity type for your account.",
+            )
+        )
 
 
 @patch("awsmp._driver.get_client")
@@ -1415,7 +1528,7 @@ def test_ami_product_update_no_pricing_change(
     ap.update(config, False)
 
     changeset_name = f"Product testing update product details"
-    mock_get_response.assert_called_once_with("some_value", changeset_name, False)
+    mock_get_response.assert_called_once_with("some_value", changeset_name, False, retry_config=None)
 
 
 @patch("awsmp._driver.get_client")


### PR DESCRIPTION
this adds new cli arguments to target specific transient failures in marketplace requests. specifically, quota issues and request already in flight. this is to avoid having to babysit situations where you are running bulk updates in CI. 

new flags:
* --retry-max-retries
* --retry-initial-delay-seconds
* --retry-max-delay-seconds