### PR TITLE
Restrict instance types fix

### DIFF
--- a/awsmp/_driver.py
+++ b/awsmp/_driver.py
@@ -147,8 +147,15 @@ class AmiProduct:
         new_instance_types = list(local_instance_types - existing_instance_types)
         removed_instance_types = list(existing_instance_types - local_instance_types)
 
+        removed_instance_type_pricing = _get_removed_instance_type_pricing(self.offer_id, removed_instance_types)
+
         changeset = changesets.get_ami_listing_update_instance_type_changesets(
-            self.product_id, self.offer_id, offer_detail, new_instance_types, removed_instance_types
+            self.product_id,
+            self.offer_id,
+            offer_detail,
+            new_instance_types,
+            removed_instance_types,
+            removed_instance_type_pricing=removed_instance_type_pricing,
         )
 
         hourly_diff, annual_diff = _get_pricing_diff(self.product_id, changeset, price_change_allowed)
@@ -384,6 +391,39 @@ def _get_full_ratecard_info(terms: List) -> Tuple[List, List]:
             annual = term["RateCards"][0]["RateCard"]
 
     return hourly, annual
+
+
+def _get_removed_instance_type_pricing(
+    offer_id: str, removed_instance_types: List[str]
+) -> Optional[List[models.InstanceTypePricing]]:
+    """
+    Fetch existing pricing for instance types being removed from the listing.
+
+    Removed instance types must still be included in the UpdatePricingTerms changeset because AWS validates
+    rate card completeness before applying RestrictDimensions/RestrictInstanceTypes in the same batch.
+    Omitting the removed types from the rate card causes a "Rates can't be removed from
+    UsageBasedPricingTerm" rejection.
+
+    :param str offer_id: offer id for fetching existing terms
+    :param List[str] removed_instance_types: instance types being removed
+    :return: pricing for removed types, or None if none are being removed
+    :rtype: Optional[List[models.InstanceTypePricing]]
+    """
+    if not removed_instance_types:
+        return None
+
+    existing_terms = get_entity_details(offer_id)["Terms"]
+    existing_hourly, existing_annual = _get_full_ratecard_info(existing_terms)
+    existing_hourly_map = {r["DimensionKey"]: r["Price"] for r in existing_hourly}
+    existing_annual_map = {r["DimensionKey"]: r["Price"] for r in existing_annual}
+    return [
+        models.InstanceTypePricing(
+            name=it,
+            price_hourly=existing_hourly_map.get(it, "0.000"),
+            price_annual=existing_annual_map.get(it),
+        )
+        for it in removed_instance_types
+    ]
 
 
 def _build_pricing_diff(existing_prices: List, local_prices: List) -> List:

--- a/awsmp/changesets.py
+++ b/awsmp/changesets.py
@@ -457,6 +457,7 @@ def get_ami_listing_update_instance_type_changesets(
     offer_detail: models.Offer,
     new_instance_types: List[str],
     removed_instance_types: List[str],
+    removed_instance_type_pricing: Optional[List[models.InstanceTypePricing]] = None,
 ) -> List[ChangeSetType]:
     """
     Return list of changeset to restrict instance types with pricing term
@@ -465,13 +466,22 @@ def get_ami_listing_update_instance_type_changesets(
     :param models.Offer offer_detail: offer configuration in local confi file
     :param List[str] new_instance_types: list of instance types to add to the listing
     :param List[str] removed_instance_types: list of instance types to remove from the listing
+    :param Optional[List[models.InstanceTypePricing]] removed_instance_type_pricing: existing pricing for
+        removed instance types. Required when removed_instance_types is non-empty. AWS requires all existing
+        dimensions to have prices in the UpdatePricingTerms rate card even when those dimensions are being
+        restricted in the same change set batch - omitting them causes a "Rates can't be removed from
+        UsageBasedPricingTerm" rejection.
     :return: List of Changesets
     :rtype: List[ChangeSetType]
     """
 
+    all_instance_type_pricing = list(offer_detail.instance_types)
+    if removed_instance_type_pricing:
+        all_instance_type_pricing.extend(removed_instance_type_pricing)
+
     changeset_list = [
         _changeset_update_pricing_terms(
-            offer_detail.instance_types,
+            all_instance_type_pricing,
             monthly_subscription_fee=offer_detail.monthly_subscription_fee,
             offer_id=offer_id,
         )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -478,6 +478,34 @@ def test_public_offer_product_update_details_restrict_instance_types(mock_get_cl
 
     mock_get_details.side_effect = [
         {"Dimensions": [{"Name": "a1.large"}, {"Name": "a1.xlarge"}, {"Name": "t1.micro"}]},
+        {
+            "Terms": [
+                {
+                    "Type": "UsageBasedPricingTerm",
+                    "RateCards": [
+                        {
+                            "RateCard": [
+                                {"DimensionKey": "a1.large", "Price": "0.004"},
+                                {"DimensionKey": "a1.xlarge", "Price": "0.007"},
+                                {"DimensionKey": "t1.micro", "Price": "0.008"},
+                            ]
+                        }
+                    ],
+                },
+                {
+                    "Type": "ConfigurableUpfrontPricingTerm",
+                    "RateCards": [
+                        {
+                            "RateCard": [
+                                {"DimensionKey": "a1.large", "Price": "24.528"},
+                                {"DimensionKey": "a1.xlarge", "Price": "49.056"},
+                                {"DimensionKey": "t1.micro", "Price": "80.00"},
+                            ]
+                        }
+                    ],
+                },
+            ]
+        },
         {"Description": {"Visibility": "Limited"}},
         {
             "Terms": [
@@ -512,6 +540,7 @@ def test_public_offer_product_update_details_restrict_instance_types(mock_get_cl
     mock_get_client.return_value.list_entities.side_effect = [
         {"EntitySummaryList": [{"EntityType": "Offer", "EntityId": "test-offer"}]},
         {"EntitySummaryList": [{"EntityType": "Offer", "EntityId": "test-offer"}]},
+        {"EntitySummaryList": [{"EntityType": "Offer", "EntityId": "test-offer"}]},
     ]
 
     runner = CliRunner()
@@ -526,6 +555,12 @@ def test_public_offer_product_update_details_restrict_instance_types(mock_get_cl
         == {"InstanceTypes": ["t1.micro"]}
         and mock_start_change_set.call_args_list[0].kwargs["ChangeSet"][4]["ChangeType"] == "RestrictInstanceTypes"
     )
+
+    rate_card = mock_start_change_set.call_args_list[0].kwargs["ChangeSet"][3]["DetailsDocument"]["Terms"][0][
+        "RateCards"
+    ][0]["RateCard"]
+    rate_card_keys = {r["DimensionKey"] for r in rate_card}
+    assert "t1.micro" in rate_card_keys
 
 
 @patch("awsmp._driver.changesets.models.boto3")
@@ -673,6 +708,34 @@ def test_public_offer_product_update_instance_type_restrict_instance_type(
 
     mock_get_details.side_effect = [
         {"Dimensions": [{"Name": "a1.large"}, {"Name": "a1.xlarge"}, {"Name": "t1.micro"}]},
+        {
+            "Terms": [
+                {
+                    "Type": "UsageBasedPricingTerm",
+                    "RateCards": [
+                        {
+                            "RateCard": [
+                                {"DimensionKey": "a1.large", "Price": "0.004"},
+                                {"DimensionKey": "a1.xlarge", "Price": "0.007"},
+                                {"DimensionKey": "t1.micro", "Price": "0.001"},
+                            ]
+                        }
+                    ],
+                },
+                {
+                    "Type": "ConfigurableUpfrontPricingTerm",
+                    "RateCards": [
+                        {
+                            "RateCard": [
+                                {"DimensionKey": "a1.large", "Price": "24.528"},
+                                {"DimensionKey": "a1.xlarge", "Price": "49.056"},
+                                {"DimensionKey": "t1.micro", "Price": "0.4"},
+                            ]
+                        }
+                    ],
+                },
+            ]
+        },
         {"Description": {"Visibility": "Limited"}},
         {
             "Terms": [
@@ -705,6 +768,7 @@ def test_public_offer_product_update_instance_type_restrict_instance_type(
     ]
 
     mock_get_client.return_value.list_entities.side_effect = [
+        {"EntitySummaryList": [{"EntityType": "Offer", "EntityId": "test-offer"}]},
         {"EntitySummaryList": [{"EntityType": "Offer", "EntityId": "test-offer"}]},
         {"EntitySummaryList": [{"EntityType": "Offer", "EntityId": "test-offer"}]},
     ]

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -254,6 +254,34 @@ def test_ami_product_update_instance_type_restrict_instance_type(mock_get_detail
     ap = _driver.AmiProduct(product_id="testing")
     mock_get_details.side_effect = [
         {"Dimensions": [{"Name": "c3.2xlarge"}, {"Name": "c3.4xlarge"}, {"Name": "c3.8xlarge"}]},
+        {
+            "Terms": [
+                {
+                    "Type": "UsageBasedPricingTerm",
+                    "RateCards": [
+                        {
+                            "RateCard": [
+                                {"DimensionKey": "c3.2xlarge", "Price": "0.00"},
+                                {"DimensionKey": "c3.4xlarge", "Price": "0.00"},
+                                {"DimensionKey": "c3.8xlarge", "Price": "0.00"},
+                            ]
+                        }
+                    ],
+                },
+                {
+                    "Type": "ConfigurableUpfrontPricingTerm",
+                    "RateCards": [
+                        {
+                            "RateCard": [
+                                {"DimensionKey": "c3.2xlarge", "Price": "0.00"},
+                                {"DimensionKey": "c3.4xlarge", "Price": "0.00"},
+                                {"DimensionKey": "c3.8xlarge", "Price": "0.00"},
+                            ]
+                        }
+                    ],
+                },
+            ]
+        },
         {"Description": {"Visibility": "Limited"}},
         {
             "Terms": [
@@ -287,6 +315,9 @@ def test_ami_product_update_instance_type_restrict_instance_type(mock_get_detail
     mock_get_details.return_value = {
         "Dimensions": [{"Name": "c3.2xlarge"}, {"Name": "c3.4xlarge"}, {"Name": "c3.8xlarge"}]
     }
+    mock_get_client.return_value.list_entities.return_value = {
+        "EntitySummaryList": [{"EntityType": "Offer", "EntityId": "test-offer"}]
+    }
     offer_config = {
         "instance_types": [
             {"name": "c3.2xlarge", "hourly": 0.00, "yearly": 0.00},
@@ -312,6 +343,34 @@ def test_ami_product_update_instance_type_restrict_and_add_instance_type(mock_ge
     ap = _driver.AmiProduct(product_id="testing")
     mock_get_details.side_effect = [
         {"Dimensions": [{"Name": "c3.2xlarge"}, {"Name": "c3.4xlarge"}, {"Name": "c3.8xlarge"}]},
+        {
+            "Terms": [
+                {
+                    "Type": "UsageBasedPricingTerm",
+                    "RateCards": [
+                        {
+                            "RateCard": [
+                                {"DimensionKey": "c3.2xlarge", "Price": "0.00"},
+                                {"DimensionKey": "c3.4xlarge", "Price": "0.00"},
+                                {"DimensionKey": "c3.8xlarge", "Price": "0.00"},
+                            ]
+                        }
+                    ],
+                },
+                {
+                    "Type": "ConfigurableUpfrontPricingTerm",
+                    "RateCards": [
+                        {
+                            "RateCard": [
+                                {"DimensionKey": "c3.2xlarge", "Price": "0.00"},
+                                {"DimensionKey": "c3.4xlarge", "Price": "0.00"},
+                                {"DimensionKey": "c3.8xlarge", "Price": "0.00"},
+                            ]
+                        }
+                    ],
+                },
+            ]
+        },
         {"Description": {"Visibility": "Limited"}},
         {
             "Terms": [
@@ -342,6 +401,9 @@ def test_ami_product_update_instance_type_restrict_and_add_instance_type(mock_ge
             ]
         },
     ]
+    mock_get_client.return_value.list_entities.return_value = {
+        "EntitySummaryList": [{"EntityType": "Offer", "EntityId": "test-offer"}]
+    }
     offer_config = {
         "instance_types": [
             {"name": "c3.2xlarge", "hourly": 0.00, "yearly": 0.00},
@@ -432,6 +494,34 @@ def test_ami_product_update_instance_type_restrict_and_add_instance_type_pricing
     ap = _driver.AmiProduct(product_id="testing")
     mock_get_details.side_effect = [
         {"Dimensions": [{"Name": "c3.2xlarge"}, {"Name": "c3.4xlarge"}, {"Name": "c3.8xlarge"}]},
+        {
+            "Terms": [
+                {
+                    "Type": "UsageBasedPricingTerm",
+                    "RateCards": [
+                        {
+                            "RateCard": [
+                                {"DimensionKey": "c3.2xlarge", "Price": "0.03"},
+                                {"DimensionKey": "c3.4xlarge", "Price": "0.12"},
+                                {"DimensionKey": "c3.8xlarge", "Price": "0.50"},
+                            ]
+                        }
+                    ],
+                },
+                {
+                    "Type": "ConfigurableUpfrontPricingTerm",
+                    "RateCards": [
+                        {
+                            "RateCard": [
+                                {"DimensionKey": "c3.2xlarge", "Price": "12.00"},
+                                {"DimensionKey": "c3.4xlarge", "Price": "24.00"},
+                                {"DimensionKey": "c3.8xlarge", "Price": "90.00"},
+                            ]
+                        }
+                    ],
+                },
+            ]
+        },
         {"Description": {"Visibility": "Limited"}},
         {
             "Terms": [
@@ -462,6 +552,9 @@ def test_ami_product_update_instance_type_restrict_and_add_instance_type_pricing
             ]
         },
     ]
+    mock_get_client.return_value.list_entities.return_value = {
+        "EntitySummaryList": [{"EntityType": "Offer", "EntityId": "test-offer"}]
+    }
     offer_config = {
         "instance_types": [
             {"name": "c3.2xlarge", "hourly": 0.03, "yearly": 12.00},
@@ -1486,6 +1579,34 @@ def test_ami_product_update_restrict_instance_types(mock_boto3, mock_get_details
 
     mock_get_details.side_effect = [
         {"Dimensions": [{"Name": "a1.large"}, {"Name": "a1.xlarge"}, {"Name": "c1.xlarge"}]},
+        {
+            "Terms": [
+                {
+                    "Type": "UsageBasedPricingTerm",
+                    "RateCards": [
+                        {
+                            "RateCard": [
+                                {"DimensionKey": "a1.large", "Price": "0.004"},
+                                {"DimensionKey": "a1.xlarge", "Price": "0.007"},
+                                {"DimensionKey": "c1.xlarge", "Price": "0.078"},
+                            ]
+                        }
+                    ],
+                },
+                {
+                    "Type": "ConfigurableUpfrontPricingTerm",
+                    "RateCards": [
+                        {
+                            "RateCard": [
+                                {"DimensionKey": "a1.large", "Price": "24.528"},
+                                {"DimensionKey": "a1.xlarge", "Price": "49.056"},
+                                {"DimensionKey": "c1.xlarge", "Price": "100.00"},
+                            ]
+                        }
+                    ],
+                },
+            ]
+        },
         {"Description": {"Visibility": "Limited"}},
         {
             "Terms": [
@@ -1532,6 +1653,12 @@ def test_ami_product_update_restrict_instance_types(mock_boto3, mock_get_details
     ] == {
         "InstanceTypes": ["c1.xlarge"]
     }
+
+    rate_card = mock_start_change_set.call_args_list[0].kwargs["ChangeSet"][3]["DetailsDocument"]["Terms"][0][
+        "RateCards"
+    ][0]["RateCard"]
+    rate_card_keys = {r["DimensionKey"] for r in rate_card}
+    assert "c1.xlarge" in rate_card_keys
 
 
 @patch("awsmp._driver.get_client")


### PR DESCRIPTION
Add better handling for removed instance types. awsmp already had logic for detecting instance types present remotely but missing from local config, and correctly generated RestrictInstanceTypes/RestrictDimensions changesets. However, the accompanying UpdatePricingTerms changeset omitted the removed types from its rate card, causing AWS to reject the entire batch since UsageBasedPricingTerm requires prices for all existing dimensions.