### PR TITLE
fix: exclude restricted instance types from entity diff

### DIFF
--- a/awsmp/_driver.py
+++ b/awsmp/_driver.py
@@ -697,7 +697,15 @@ def diff_entity_id_vs_local(entity_id: str, local_entity: models.EntityModel):
     Fetch live by id, compare against provided local model.
     """
 
-    entity_from_listing = models.EntityModel(**get_full_response(entity_id))
-    diff = entity_from_listing.get_diff(local_entity)
+    full_response = get_full_response(entity_id)
+    restricted_instance_types: set[str] = set()
+    compatibility = full_response.get("Compatibility")
+    if isinstance(compatibility, dict):
+        restricted = compatibility.get("RestrictedInstanceTypes")
+        if isinstance(restricted, list):
+            restricted_instance_types = set(restricted)
+
+    entity_from_listing = models.EntityModel(**full_response)
+    diff = entity_from_listing.get_diff(local_entity, restricted_instance_types=restricted_instance_types)
 
     return diff

--- a/awsmp/models.py
+++ b/awsmp/models.py
@@ -1060,6 +1060,7 @@ class EntityModel(BaseModel):
         diff_added: List[DiffAddedModel],
         diff_removed: List[DiffRemovedModel],
         diff_changed: List[DiffChangedModel],
+        restricted_instance_types: Optional[set[str]] = None,
     ) -> None:
         """
         Helper function to compare ratecard
@@ -1084,11 +1085,15 @@ class EntityModel(BaseModel):
         for dimension_key in entity_rate_cards:
             # instance type removed
             if dimension_key not in local_rate_cards:
+                if restricted_instance_types and dimension_key in restricted_instance_types:
+                    continue
                 EntityModel._add_diff(
                     term_type, entity_rate_cards[dimension_key], None, diff_added, diff_removed, diff_changed
                 )
 
-    def _get_diff_model(self, local_entity: EntityModel) -> DiffModel:
+    def _get_diff_model(
+        self, local_entity: EntityModel, restricted_instance_types: Optional[set[str]] = None
+    ) -> DiffModel:
         """
         Get complete DiffModel instance of diff from listing and local config
 
@@ -1167,9 +1172,10 @@ class EntityModel(BaseModel):
                                             diff_added,
                                             diff_removed,
                                             diff_changed,
+                                            restricted_instance_types=restricted_instance_types,
                                         )
 
         return DiffModel(added=diff_added, removed=diff_removed, changed=diff_changed)
 
-    def get_diff(self, local_entity: EntityModel) -> DiffModel:
-        return self._get_diff_model(local_entity)
+    def get_diff(self, local_entity: EntityModel, restricted_instance_types: Optional[set[str]] = None) -> DiffModel:
+        return self._get_diff_model(local_entity, restricted_instance_types=restricted_instance_types)

--- a/tests/local_config/test_config_8.yaml
+++ b/tests/local_config/test_config_8.yaml
@@ -1,0 +1,57 @@
+product:
+  description:
+    product_title: "test"
+    logourl: "https://test-logourl"
+    video_urls: []
+    short_description: "test_short_description"
+    long_description: |
+      test_long_description
+    highlights:
+      - "test_highlight_1"
+    search_keywords:
+      - "test_keyword_1"
+    categories:
+      - "Migration"
+    support_description: |
+      test_support_description
+    support_resources: 
+      - "test_support_resource"
+    additional_resources:
+      - test-link: "https://test-url"
+    sku: "test"
+  region:
+    commercial_regions:
+      - us-east-1
+      - us-east-2
+    future_region_support: true
+  version:
+    version_title: "test_version_title_1"
+    release_notes: |
+      test_release_notes
+    ami_id: ami-test1
+    access_role_arn: arn:aws:iam::test
+    os_user_name: test_os_user_name
+    os_system_version: test_os_system_version
+    os_system_name: test_os
+    scanning_port: 22
+    usage_instructions: |
+      test_usage_instructions
+    recommended_instance_type: m5.large
+    ip_protocol: tcp
+    ip_ranges:
+      - "0.0.0.0/0"
+    from_port: 22
+    to_port: 22
+offer:
+  refund_policy: |
+    test_refund_policy_term
+  eula_document:
+    - type: "CustomEula"
+      url: "test_eula_url"
+  instance_types:
+    - name: "a1.large"
+      hourly: 0.004
+      yearly: 24.528
+    - name: "a1.xlarge"
+      hourly: 0.007
+      yearly: 49.056

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -299,6 +299,50 @@ def test_entity_get_diff_pricing_terms(
     assert result.output.strip() == json.dumps(expected_diff, indent=2).strip()
 
 
+@patch("awsmp._driver.get_public_offer_id")
+@patch("awsmp._driver.get_entity_details")
+@patch("awsmp.models.boto3")
+def test_entity_get_diff_restricted_instance_types(mock_boto3, mock_get_entity_details, mock_get_public_offer_id):
+    mock_boto3.client.return_value.describe_regions.return_value = {
+        "Regions": [
+            {"Endpoint": "ec2.us-east-1.amazonaws.com", "RegionName": "us-east-1", "OptInStatus": "opted-in"},
+            {"Endpoint": "ec2.us-east-2.amazonaws.com", "RegionName": "us-east-2", "OptInStatus": "opted-in"},
+        ]
+    }
+
+    with open("./tests/test_config.json") as f:
+        test_config = json.load(f)
+
+    mock_prod_resp = test_config.copy()
+    mock_prod_resp.pop("Terms")
+    mock_prod_resp["Versions"] = [mock_prod_resp["Versions"]]
+    mock_prod_resp["Compatibility"] = {
+        "AvailableInstanceTypes": ["a1.large", "a1.xlarge"],
+        "RestrictedInstanceTypes": ["c1.xlarge"],
+    }
+
+    base_terms = test_config["Terms"]
+    for term in base_terms:
+        if "RateCards" in term:
+            for rc in term["RateCards"]:
+                if "RateCard" in rc:
+                    rc["RateCard"].append({"DimensionKey": "c1.xlarge", "Price": "0.078"})
+                elif "Selector" in rc:
+                    rc["RateCard"].append({"DimensionKey": "c1.xlarge", "Price": "100.00"})
+    mock_offer_resp = {"Terms": base_terms}
+
+    mock_get_public_offer_id.return_value = "test-offer-id"
+    mock_get_entity_details.side_effect = [mock_prod_resp, mock_offer_resp]
+
+    runner = CliRunner()
+    result = runner.invoke(cli.entity_get_diff, ["temp-list", "./tests/local_config/test_config_8.yaml"])
+    diff_data = json.loads(result.output)
+
+    removed_keys = [r["name"] for r in diff_data.get("removed", [])]
+    assert "UsageBasedPricingTerm" not in removed_keys
+    assert "ConfigurableUpfrontPricingTerm" not in removed_keys
+
+
 @patch("awsmp._driver.changesets.models.boto3")
 @patch("awsmp._driver.get_entity_details")
 @patch("awsmp._driver.get_client")


### PR DESCRIPTION
Restricted instance types cannot be removed from a live listing, so they should not appear as diffs when present in the AWS rate card but absent from local config. Extract RestrictedInstanceTypes from the entity's Compatibility field and pass them through the diff chain so _compare_rate_cards skips them when checking for removed dimensions.

Tested locally. No longer finds restricted instance types

awsmp inspect entity-diff prod-qls2nau5pwovi $(fd prod-qls2nau5pwovi)
2026-06-01 07:21:51,318:botocore.credentials:INFO:Found credentials in shared credentials file: ~/.aws/credentials
{
  "added": [],
  "removed": [
    {
      "name": "UsageBasedPricingTerm",
      "value": {
        "DimensionKey": "m1.xlarge",
        "Price": "0.00"
      }
    },
    ...

awsmp inspect entity-diff prod-qls2nau5pwovi $(fd prod-qls2nau5pwovi)
2026-06-01 07:27:27,099:botocore.credentials:INFO:Found credentials in shared credentials file: ~/.aws/credentials
{
  "added": [],
  "removed": [],
  "changed": []
}