### PR TITLE
fix(restrict-types): keep restricted instance type pricing in sync ac…

### DIFF
--- a/awsmp/_driver.py
+++ b/awsmp/_driver.py
@@ -143,25 +143,63 @@ class AmiProduct:
         offer_detail = models.Offer(**offer_config)
 
         local_instance_types = {instance_type.name for instance_type in offer_detail.instance_types}
-        existing_instance_types = _get_existing_instance_types(self.product_id)
-        new_instance_types = list(local_instance_types - existing_instance_types)
-        removed_instance_types = list(existing_instance_types - local_instance_types)
+        (
+            existing_instance_types,
+            already_restricted_instance_types,
+            available_instance_types,
+        ) = _get_existing_restricted_and_available_instance_types(self.product_id)
 
-        removed_instance_type_pricing = _get_removed_instance_type_pricing(self.offer_id, removed_instance_types)
+        # The offer's live rate card is the authoritative source of dimensions AWS validates completeness
+        # against - it can diverge from the AmiProduct's Dimensions list (e.g. a dimension priced on the
+        # offer but not yet reflected in Compatibility/Dimensions on the product side). Always fall back to
+        # it so we never drop a price AWS still expects.
+        existing_terms = get_entity_details(self.offer_id)["Terms"]
+        existing_hourly, existing_annual = _get_full_ratecard_info(existing_terms)
+        existing_hourly_map = {r["DimensionKey"]: r["Price"] for r in existing_hourly}
+        existing_annual_map = {r["DimensionKey"]: r["Price"] for r in existing_annual}
+        existing_priced_instance_types = set(existing_hourly_map) | set(existing_annual_map)
+
+        # Any local type that is not already available must be added. This covers both brand-new types and
+        # previously restricted types that the caller is adding back to the listing.
+        new_instance_types = list(local_instance_types - available_instance_types)
+        # Dimensions are never deleted, so only brand-new types need an AddDimensions changeset. Types that
+        # were restricted already have a dimension and only need AddInstanceTypes to make them available again.
+        new_dimension_instance_types = list(set(new_instance_types) - existing_instance_types)
+
+        # Instance types that must keep their pricing: anything currently a product dimension, or currently
+        # priced on the offer, that isn't in the local config. Rate card entries can never be removed, so
+        # any of these must still be supplied a price in the outgoing UpdatePricingTerms changeset.
+        removed_instance_types = (existing_instance_types | existing_priced_instance_types) - local_instance_types
+
+        # RestrictInstanceTypes/RestrictDimensions only operate on types that exist as a product dimension.
+        # An offer-only priced type (present in the rate card but not yet reflected in the product's
+        # Dimensions) has nothing to restrict on the product side - including it would ask AWS to restrict a
+        # dimension that doesn't exist there. Its price is still preserved via removed_instance_types/
+        # removed_instance_type_pricing above; it's simply excluded from these two changesets.
+        # Instance types already restricted on the live listing must also be excluded, since AWS rejects
+        # restricting an instance type that is already restricted.
+        newly_removed_instance_types = list(
+            (removed_instance_types & existing_instance_types) - already_restricted_instance_types
+        )
+
+        removed_instance_type_pricing = _get_removed_instance_type_pricing(
+            list(removed_instance_types), existing_hourly_map, existing_annual_map
+        )
 
         changeset = changesets.get_ami_listing_update_instance_type_changesets(
             self.product_id,
             self.offer_id,
             offer_detail,
             new_instance_types,
-            removed_instance_types,
+            newly_removed_instance_types,
+            new_dimension_instance_types=new_dimension_instance_types,
             removed_instance_type_pricing=removed_instance_type_pricing,
         )
 
-        hourly_diff, annual_diff = _get_pricing_diff(self.product_id, changeset, price_change_allowed)
+        hourly_diff, annual_diff = _get_pricing_diff(self.product_id, changeset, price_change_allowed, existing_terms)
 
         if not hourly_diff and not annual_diff:
-            if not new_instance_types and not removed_instance_types:
+            if not new_instance_types and not newly_removed_instance_types:
                 # There are nothing to update
                 logger.info("There is no instance information details to update.")
                 return None, [], []
@@ -394,28 +432,27 @@ def _get_full_ratecard_info(terms: List) -> Tuple[List, List]:
 
 
 def _get_removed_instance_type_pricing(
-    offer_id: str, removed_instance_types: List[str]
+    removed_instance_types: List[str],
+    existing_hourly_map: Dict[str, str],
+    existing_annual_map: Dict[str, str],
 ) -> Optional[List[models.InstanceTypePricing]]:
     """
-    Fetch existing pricing for instance types being removed from the listing.
+    Build pricing entries for instance types being removed/restricted from the listing.
 
     Removed instance types must still be included in the UpdatePricingTerms changeset because AWS validates
     rate card completeness before applying RestrictDimensions/RestrictInstanceTypes in the same batch.
     Omitting the removed types from the rate card causes a "Rates can't be removed from
     UsageBasedPricingTerm" rejection.
 
-    :param str offer_id: offer id for fetching existing terms
     :param List[str] removed_instance_types: instance types being removed
+    :param Dict[str, str] existing_hourly_map: dimension key -> hourly price from the live offer rate card
+    :param Dict[str, str] existing_annual_map: dimension key -> annual price from the live offer rate card
     :return: pricing for removed types, or None if none are being removed
     :rtype: Optional[List[models.InstanceTypePricing]]
     """
     if not removed_instance_types:
         return None
 
-    existing_terms = get_entity_details(offer_id)["Terms"]
-    existing_hourly, existing_annual = _get_full_ratecard_info(existing_terms)
-    existing_hourly_map = {r["DimensionKey"]: r["Price"] for r in existing_hourly}
-    existing_annual_map = {r["DimensionKey"]: r["Price"] for r in existing_annual}
     return [
         models.InstanceTypePricing(
             name=it,
@@ -450,11 +487,14 @@ def _build_pricing_diff(existing_prices: List, local_prices: List) -> List:
     return diffs
 
 
-def _get_pricing_diff(product_id: str, changeset: List[ChangeSetType], allow_price_update: bool) -> Tuple[List, List]:
+def _get_pricing_diff(
+    product_id: str, changeset: List[ChangeSetType], allow_price_update: bool, existing_terms: List
+) -> Tuple[List, List]:
     """
     Check if there are differences between the given changeset from the local configuration and the existing listing pricing terms
     :param str product_id: product id of existing/live listing
     :param List[ChangeSetType] chageset: changeset from local configuration file
+    :param List existing_terms: Terms from the live public offer, already fetched by the caller
     :return: Hourly and Anuual pricing diff details
     :rtype: Tuple[List, List]
     """
@@ -465,7 +505,6 @@ def _get_pricing_diff(product_id: str, changeset: List[ChangeSetType], allow_pri
 
     # existing pricing information from the listing
     existing_listing_status = get_entity_details(product_id)["Description"]["Visibility"]
-    existing_terms = get_entity_details(get_public_offer_id(product_id))["Terms"]
     existing_hourly, existing_annual = _get_full_ratecard_info(existing_terms)
 
     diffs_hourly = _build_pricing_diff(existing_hourly, local_hourly)
@@ -482,8 +521,6 @@ def _get_pricing_diff(product_id: str, changeset: List[ChangeSetType], allow_pri
         raise AmiPriceChangeError(error_message)
     elif existing_listing_status != "Draft" and _has_different_pricing_model():
         raise AmiPricingModelChangeError("Listing is published. Contact AWS Marketplace to change the pricing type.")
-
-    existing_hourly, existing_annual = _get_full_ratecard_info(existing_terms)
 
     def any_zero_to_paid(diffs):
         # check if pricing request from free (0.0) to non-zero prices
@@ -558,6 +595,46 @@ def _get_existing_instance_types(product_id: str):
     if "Dimensions" in entity:
         existing_instance_types = {t["Name"] for t in entity["Dimensions"]}
     return existing_instance_types
+
+
+def _get_existing_restricted_and_available_instance_types(product_id: str) -> Tuple[set[str], set[str], set[str]]:
+    """
+    Return the existing instance types (pricing dimensions), the subset already restricted, and the subset
+    currently available on the live listing, from a single ``get_entity_details`` call.
+
+    Pricing dimensions can never be deleted once created, so an instance type that was restricted in a
+    previous update remains in ``Dimensions`` forever. Without excluding already-restricted types from the
+    "to be restricted" set, every subsequent apply would resubmit RestrictInstanceTypes/RestrictDimensions
+    changesets for types that are already restricted, which AWS rejects.
+
+    Re-adding a previously restricted instance type requires an ``AddInstanceTypes`` changeset, so callers
+    should compare local configuration against ``available_instance_types`` rather than ``Dimensions`` when
+    deciding which types to add.
+
+    :param str product_id: product id of the listing
+    :return: tuple of (existing instance type names, already-restricted instance type names, available instance type names)
+    :rtype: Tuple[set[str], set[str], set[str]]
+    """
+    entity = get_entity_details(product_id)
+    existing_instance_types = set()
+    if "Dimensions" in entity:
+        existing_instance_types = {t["Name"] for t in entity["Dimensions"]}
+
+    compatibility = entity.get("Compatibility")
+    if not isinstance(compatibility, dict):
+        return existing_instance_types, set(), existing_instance_types
+
+    restricted_instance_types: set[str] = set()
+    restricted = compatibility.get("RestrictedInstanceTypes")
+    if isinstance(restricted, list):
+        restricted_instance_types = set(restricted)
+
+    available_instance_types = existing_instance_types - restricted_instance_types
+    available = compatibility.get("AvailableInstanceTypes")
+    if isinstance(available, list):
+        available_instance_types = set(available)
+
+    return existing_instance_types, restricted_instance_types, available_instance_types
 
 
 def get_available_instance_types(arch: str, virt: str) -> list[str]:

--- a/awsmp/changesets.py
+++ b/awsmp/changesets.py
@@ -457,6 +457,7 @@ def get_ami_listing_update_instance_type_changesets(
     offer_detail: models.Offer,
     new_instance_types: List[str],
     removed_instance_types: List[str],
+    new_dimension_instance_types: Optional[List[str]] = None,
     removed_instance_type_pricing: Optional[List[models.InstanceTypePricing]] = None,
 ) -> List[ChangeSetType]:
     """
@@ -464,8 +465,12 @@ def get_ami_listing_update_instance_type_changesets(
     :param str product_id: product id
     :param str offer_id: offer id
     :param models.Offer offer_detail: offer configuration in local confi file
-    :param List[str] new_instance_types: list of instance types to add to the listing
+    :param List[str] new_instance_types: list of instance types to add to the listing (including types that
+        were previously restricted and are being added back)
     :param List[str] removed_instance_types: list of instance types to remove from the listing
+    :param Optional[List[str]] new_dimension_instance_types: subset of ``new_instance_types`` that do not
+        already have a pricing dimension and therefore require an ``AddDimensions`` changeset. Defaults to
+        ``new_instance_types``.
     :param Optional[List[models.InstanceTypePricing]] removed_instance_type_pricing: existing pricing for
         removed instance types. Required when removed_instance_types is non-empty. AWS requires all existing
         dimensions to have prices in the UpdatePricingTerms rate card even when those dimensions are being
@@ -487,12 +492,12 @@ def get_ami_listing_update_instance_type_changesets(
         )
     ]
     if new_instance_types:
-        changeset_list.extend(
-            [
-                _changeset_update_ami_product_dimension(product_id, new_instance_types),
-                _changeset_update_ami_product_instance_type(product_id, new_instance_types),
-            ]
+        dimension_types = (
+            new_dimension_instance_types if new_dimension_instance_types is not None else new_instance_types
         )
+        if dimension_types:
+            changeset_list.append(_changeset_update_ami_product_dimension(product_id, dimension_types))
+        changeset_list.append(_changeset_update_ami_product_instance_type(product_id, new_instance_types))
     if removed_instance_types:
         changeset_list.extend(
             [

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -356,7 +356,6 @@ def test_public_offer_product_update_details(mock_get_client, mock_get_details, 
 
     mock_get_details.side_effect = [
         {"Dimensions": [{"Name": "a1.large"}]},
-        {"Description": {"Visibility": "Limited"}},
         {
             "Terms": [
                 {
@@ -381,6 +380,7 @@ def test_public_offer_product_update_details(mock_get_client, mock_get_details, 
                 },
             ]
         },
+        {"Description": {"Visibility": "Limited"}},
     ]
 
     mock_get_client.return_value.list_entities.side_effect = [
@@ -414,7 +414,6 @@ def test_public_offer_product_update_details_pricing_change(mock_get_client, moc
 
     mock_get_details.side_effect = [
         {"Dimensions": [{"Name": "a1.large"}, {"Name": "a1.xlarge"}]},
-        {"Description": {"Visibility": "Limited"}},
         {
             "Terms": [
                 {
@@ -441,6 +440,7 @@ def test_public_offer_product_update_details_pricing_change(mock_get_client, moc
                 },
             ]
         },
+        {"Description": {"Visibility": "Limited"}},
     ]
 
     mock_get_client.return_value.list_entities.side_effect = [
@@ -474,7 +474,6 @@ def test_public_offer_product_update_details_raise_exception(mock_get_client, mo
 
     mock_get_details.side_effect = [
         {"Dimensions": [{"Name": "a1.large"}, {"Name": "a1.xlarge"}]},
-        {"Description": {"Visibility": "Restricted"}},
         {
             "Terms": [
                 {
@@ -490,6 +489,7 @@ def test_public_offer_product_update_details_raise_exception(mock_get_client, mo
                 },
             ]
         },
+        {"Description": {"Visibility": "Restricted"}},
     ]
 
     mock_get_client.return_value.list_entities.side_effect = [
@@ -622,7 +622,6 @@ def test_public_offer_product_update_details_pricing_change_allowed(
 
     mock_get_details.side_effect = [
         {"Dimensions": [{"Name": "a1.large"}, {"Name": "a1.xlarge"}]},
-        {"Description": {"Visibility": "Limited"}},
         {
             "Terms": [
                 {
@@ -649,6 +648,7 @@ def test_public_offer_product_update_details_pricing_change_allowed(
                 },
             ]
         },
+        {"Description": {"Visibility": "Limited"}},
     ]
 
     mock_get_client.return_value.list_entities.side_effect = [
@@ -691,7 +691,6 @@ def test_public_offer_product_update_instance_type(mock_get_client, mock_get_det
 
     mock_get_details.side_effect = [
         {"Dimensions": [{"Name": "a1.large"}]},
-        {"Description": {"Visibility": "Limited"}},
         {
             "Terms": [
                 {
@@ -716,6 +715,7 @@ def test_public_offer_product_update_instance_type(mock_get_client, mock_get_det
                 },
             ]
         },
+        {"Description": {"Visibility": "Limited"}},
     ]
 
     mock_get_client.return_value.list_entities.side_effect = [
@@ -834,6 +834,120 @@ def test_public_offer_product_update_instance_type_restrict_instance_type(
 @patch("awsmp._driver.changesets.models.boto3")
 @patch("awsmp._driver.get_entity_details")
 @patch("awsmp._driver.get_client")
+def test_public_offer_product_update_instance_type_already_restricted_instance_type(
+    mock_get_client, mock_get_details, mock_boto3
+):
+    """
+    An instance type already restricted on a previous apply must keep its pricing (rate card entries can
+    never be removed) but must not be resubmitted in a RestrictInstanceTypes/RestrictDimensions changeset.
+    """
+    mock_boto3.client.return_value.describe_regions.return_value = {
+        "Regions": [
+            {"Endpoint": "ec2.us-east-1.amazonaws.com", "RegionName": "us-east-1", "OptInStatus": "opted-in"},
+            {"Endpoint": "ec2.us-east-2.amazonaws.com", "RegionName": "us-east-2", "OptInStatus": "opted-in"},
+        ]
+    }
+
+    mock_get_details.side_effect = [
+        {
+            "Dimensions": [{"Name": "a1.large"}, {"Name": "a1.xlarge"}, {"Name": "t1.micro"}],
+            "Compatibility": {
+                "AvailableInstanceTypes": ["a1.large", "a1.xlarge"],
+                "RestrictedInstanceTypes": ["t1.micro"],
+            },
+        },
+        {
+            "Terms": [
+                {
+                    "Type": "UsageBasedPricingTerm",
+                    "RateCards": [
+                        {
+                            "RateCard": [
+                                {"DimensionKey": "a1.large", "Price": "0.004"},
+                                {"DimensionKey": "a1.xlarge", "Price": "0.007"},
+                                {"DimensionKey": "t1.micro", "Price": "0.001"},
+                            ]
+                        }
+                    ],
+                },
+                {
+                    "Type": "ConfigurableUpfrontPricingTerm",
+                    "RateCards": [
+                        {
+                            "RateCard": [
+                                {"DimensionKey": "a1.large", "Price": "24.528"},
+                                {"DimensionKey": "a1.xlarge", "Price": "49.056"},
+                                {"DimensionKey": "t1.micro", "Price": "0.4"},
+                            ]
+                        }
+                    ],
+                },
+            ]
+        },
+        {"Description": {"Visibility": "Limited"}},
+        {
+            "Terms": [
+                {
+                    "Type": "UsageBasedPricingTerm",
+                    "RateCards": [
+                        {
+                            "RateCard": [
+                                {"DimensionKey": "a1.large", "Price": "0.004"},
+                                {"DimensionKey": "a1.xlarge", "Price": "0.007"},
+                                {"DimensionKey": "t1.micro", "Price": "0.001"},
+                            ]
+                        }
+                    ],
+                },
+                {
+                    "Type": "ConfigurableUpfrontPricingTerm",
+                    "RateCards": [
+                        {
+                            "RateCard": [
+                                {"DimensionKey": "a1.large", "Price": "24.528"},
+                                {"DimensionKey": "a1.xlarge", "Price": "49.056"},
+                                {"DimensionKey": "t1.micro", "Price": "0.4"},
+                            ]
+                        }
+                    ],
+                },
+            ]
+        },
+    ]
+
+    mock_get_client.return_value.list_entities.side_effect = [
+        {"EntitySummaryList": [{"EntityType": "Offer", "EntityId": "test-offer"}]},
+        {"EntitySummaryList": [{"EntityType": "Offer", "EntityId": "test-offer"}]},
+    ]
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli.ami_product_update_instance_type,
+        [
+            "--product-id",
+            "some-prod-id",
+            "--config",
+            "./tests/test_config_new_instance_type.yaml",
+            "--no-allow-price-change",
+        ],
+    )
+    assert result.exit_code == 0
+
+    mock_start_change_set = mock_get_client.return_value.start_change_set
+    changeset = mock_start_change_set.call_args_list[0].kwargs["ChangeSet"]
+
+    # No restrict changeset should be resubmitted for the already-restricted instance type.
+    assert not any(c["ChangeType"] in ("RestrictInstanceTypes", "RestrictDimensions") for c in changeset)
+
+    # The already-restricted instance type's pricing must still be present in the rate card, alongside the
+    # newly added instance type.
+    hourly_rate_card = changeset[0]["DetailsDocument"]["Terms"][0]["RateCards"][0]["RateCard"]
+    assert {r["DimensionKey"] for r in hourly_rate_card} == {"a1.large", "a1.xlarge", "t1.micro", "m5.large"}
+
+
+@patch("awsmp._driver.changesets.models.boto3")
+@patch("awsmp._driver.get_entity_details")
+@patch("awsmp._driver.get_client")
 def test_public_offer_product_update_instance_type_pricing_change(mock_get_client, mock_get_details, mock_boto3):
     mock_boto3.client.return_value.describe_regions.return_value = {
         "Regions": [
@@ -844,7 +958,6 @@ def test_public_offer_product_update_instance_type_pricing_change(mock_get_clien
 
     mock_get_details.side_effect = [
         {"Dimensions": [{"Name": "a1.large"}, {"Name": "a1.xlarge"}]},
-        {"Description": {"Visibility": "Limited"}},
         {
             "Terms": [
                 {
@@ -871,6 +984,7 @@ def test_public_offer_product_update_instance_type_pricing_change(mock_get_clien
                 },
             ]
         },
+        {"Description": {"Visibility": "Limited"}},
     ]
 
     mock_get_client.return_value.list_entities.side_effect = [
@@ -970,7 +1084,6 @@ def test_public_offer_product_update_instance_type_pricing_change_exception(
 
     mock_get_details.side_effect = [
         {"Dimensions": [{"Name": "a1.large"}, {"Name": "a1.xlarge"}]},
-        {"Description": {"Visibility": "Restricted"}},
         {
             "Terms": [
                 {
@@ -986,6 +1099,7 @@ def test_public_offer_product_update_instance_type_pricing_change_exception(
                 },
             ]
         },
+        {"Description": {"Visibility": "Restricted"}},
     ]
 
     mock_get_client.return_value.list_entities.side_effect = [

--- a/tests/test_config_new_instance_type.yaml
+++ b/tests/test_config_new_instance_type.yaml
@@ -1,0 +1,60 @@
+offer:
+  refund_policy: |
+    test_refund_policy_term
+  eula_document:
+    - type: "CustomEula"
+      url: "test_eula_url"
+  instance_types:
+    - name: "a1.large"
+      hourly: 0.004
+      yearly: 24.528
+    - name: "a1.xlarge"
+      hourly: 0.007
+      yearly: 49.056
+    - name: "m5.large"
+      hourly: 0.096
+      yearly: 588.672
+product:
+  description:
+    product_title: "test"
+    logourl: "https://test-logourl"
+    video_urls: []
+    short_description: "test_short_description"
+    long_description: |
+      test_long_description
+    highlights:
+      - "test_highlight_1"
+    search_keywords:
+      - "test_keyword_1"
+    categories:
+      - "Migration"
+    support_description: |
+      test_support_description
+    support_resources:
+      - "test_support_resource"
+    additional_resources:
+      - test-link: "https://test-url"
+    sku: "test"
+  region:
+    commercial_regions:
+      - us-east-1
+      - us-east-2
+    future_region_support: true
+  version:
+    version_title: "test_version_title"
+    release_notes: |
+      test_release_notes
+    ami_id: ami-test
+    access_role_arn: arn:aws:iam::test
+    os_user_name: test_os_user_name
+    os_system_version: test_os_system_version
+    os_system_name: test_os
+    scanning_port: 22
+    usage_instructions: |
+      test_usage_instructions
+    recommended_instance_type: m5.large
+    ip_protocol: tcp
+    ip_ranges:
+      - "0.0.0.0/0"
+    from_port: 22
+    to_port: 22

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -186,7 +186,6 @@ def test_ami_product_update_instance_type(mock_get_details, mock_get_client):
     ap = _driver.AmiProduct(product_id="testing")
     mock_get_details.side_effect = [
         {"Dimensions": [{"Name": "c3.2xlarge"}, {"Name": "c3.4xlarge"}, {"Name": "c3.8xlarge"}]},
-        {"Description": {"Visibility": "Limited"}},
         {
             "Terms": [
                 {
@@ -215,6 +214,7 @@ def test_ami_product_update_instance_type(mock_get_details, mock_get_client):
                 },
             ]
         },
+        {"Description": {"Visibility": "Limited"}},
     ]
     offer_config = {
         "instance_types": [
@@ -246,6 +246,164 @@ def test_ami_product_update_instance_type(mock_get_details, mock_get_client):
         ][0]["RateCards"][0]["RateCard"][-1]["Price"]
         == "0.0"
     )
+
+
+@patch("awsmp._driver.get_client")
+@patch("awsmp._driver.get_entity_details")
+def test_ami_product_update_instance_type_uses_offer_rate_card_for_removed_pricing(mock_get_details, mock_get_client):
+    """
+    Regression test: the offer's live rate card, not the product's Dimensions list, must be the source of
+    truth for which instance types need their pricing preserved when removed from the local config, while
+    only actual product dimensions may be sent to the RestrictInstanceTypes/RestrictDimensions changesets.
+
+    "c3.8xlarge" is a real product dimension being removed from the local config, so it must be restricted.
+    "c3.16xlarge" is priced on the offer's rate card but missing from the product's Dimensions (simulating
+    drift between the AmiProduct entity and the Offer entity). Removing it from the local config must still
+    keep its price in the outgoing UpdatePricingTerms changeset, otherwise AWS rejects the changeset with
+    "Rates can't be removed from UsageBasedPricingTerm". However, since "c3.16xlarge" is not a product
+    dimension, it must NOT be included in the RestrictInstanceTypes/RestrictDimensions changesets - AWS
+    cannot restrict a product dimension that doesn't exist.
+    """
+    ap = _driver.AmiProduct(product_id="testing")
+    mock_get_details.side_effect = [
+        {"Dimensions": [{"Name": "c3.2xlarge"}, {"Name": "c3.4xlarge"}, {"Name": "c3.8xlarge"}]},
+        {
+            "Terms": [
+                {
+                    "Type": "UsageBasedPricingTerm",
+                    "RateCards": [
+                        {
+                            "RateCard": [
+                                {"DimensionKey": "c3.2xlarge", "Price": "0.00"},
+                                {"DimensionKey": "c3.4xlarge", "Price": "0.00"},
+                                {"DimensionKey": "c3.8xlarge", "Price": "0.02"},
+                                {"DimensionKey": "c3.16xlarge", "Price": "0.05"},
+                            ]
+                        }
+                    ],
+                },
+                {
+                    "Type": "ConfigurableUpfrontPricingTerm",
+                    "RateCards": [
+                        {
+                            "RateCard": [
+                                {"DimensionKey": "c3.2xlarge", "Price": "0.00"},
+                                {"DimensionKey": "c3.4xlarge", "Price": "0.00"},
+                                {"DimensionKey": "c3.8xlarge", "Price": "120.00"},
+                                {"DimensionKey": "c3.16xlarge", "Price": "300.00"},
+                            ]
+                        }
+                    ],
+                },
+            ]
+        },
+        {"Description": {"Visibility": "Limited"}},
+    ]
+    offer_config = {
+        "instance_types": [
+            {"name": "c3.2xlarge", "hourly": 0.00, "yearly": 0.00},
+            {"name": "c3.4xlarge", "hourly": 0.00, "yearly": 0.00},
+        ],
+        "refund_policy": "refund_policy",
+        "eula_document": [{"type": "StandardEula", "version": "2025-04-05"}],
+    }
+
+    mock_get_client.return_value.list_entities.return_value = {
+        "EntitySummaryList": [{"EntityType": "Offer", "EntityId": "test-offer"}]
+    }
+    change_set, hourly_diff, annual_diff = ap._get_instance_type_changeset_and_pricing_diff(offer_config, False)
+
+    assert change_set is not None
+    pricing_details = change_set[0]["DetailsDocument"]["Terms"]
+    hourly_rate_card = next(t for t in pricing_details if t["Type"] == "UsageBasedPricingTerm")["RateCards"][0][
+        "RateCard"
+    ]
+    # Both the real dimension and the offer-only dimension must keep their price.
+    assert {"DimensionKey": "c3.8xlarge", "Price": "0.02"} in hourly_rate_card
+    assert {"DimensionKey": "c3.16xlarge", "Price": "0.05"} in hourly_rate_card
+
+    # Only the real product dimension "c3.8xlarge" may be restricted; "c3.16xlarge" is not a product
+    # dimension and must be excluded from both changesets.
+    restrict_instance_types = next(
+        c["DetailsDocument"] for c in change_set if c["ChangeType"] == "RestrictInstanceTypes"
+    )
+    assert restrict_instance_types == {"InstanceTypes": ["c3.8xlarge"]}
+    restrict_dimensions = next(c["DetailsDocument"] for c in change_set if c["ChangeType"] == "RestrictDimensions")
+    assert restrict_dimensions == [{"Key": "c3.8xlarge", "Types": ["Metered"]}]
+
+
+@patch("awsmp._driver.get_client")
+@patch("awsmp._driver.get_entity_details")
+def test_ami_product_update_instance_type_add_back_restricted_instance_type(mock_get_details, mock_get_client):
+    """
+    A previously restricted instance type that is added back to the local config must receive an
+    AddInstanceTypes changeset so it becomes available again. Its pricing dimension already exists, so no
+    AddDimensions changeset should be emitted for it.
+    """
+    ap = _driver.AmiProduct(product_id="testing")
+    mock_get_details.side_effect = [
+        {
+            "Dimensions": [{"Name": "a1.large"}, {"Name": "t1.micro"}],
+            "Compatibility": {
+                "AvailableInstanceTypes": ["a1.large"],
+                "RestrictedInstanceTypes": ["t1.micro"],
+            },
+        },
+        {
+            "Terms": [
+                {
+                    "Type": "UsageBasedPricingTerm",
+                    "RateCards": [
+                        {
+                            "RateCard": [
+                                {"DimensionKey": "a1.large", "Price": "0.004"},
+                                {"DimensionKey": "t1.micro", "Price": "0.001"},
+                            ]
+                        }
+                    ],
+                },
+                {
+                    "Type": "ConfigurableUpfrontPricingTerm",
+                    "RateCards": [
+                        {
+                            "RateCard": [
+                                {"DimensionKey": "a1.large", "Price": "24.528"},
+                                {"DimensionKey": "t1.micro", "Price": "0.4"},
+                            ]
+                        }
+                    ],
+                },
+            ]
+        },
+        {"Description": {"Visibility": "Limited"}},
+    ]
+    offer_config = {
+        "instance_types": [
+            {"name": "a1.large", "hourly": 0.004, "yearly": 24.528},
+            {"name": "t1.micro", "hourly": 0.001, "yearly": 0.4},
+        ],
+        "refund_policy": "refund_policy",
+        "eula_document": [{"type": "StandardEula", "version": "2025-04-05"}],
+    }
+
+    mock_get_client.return_value.list_entities.return_value = {
+        "EntitySummaryList": [{"EntityType": "Offer", "EntityId": "test-offer"}]
+    }
+    ap.update_instance_types(offer_config, False)
+
+    change_set = mock_get_client.return_value.start_change_set.call_args_list[0].kwargs["ChangeSet"]
+
+    # The re-added restricted type should be in an AddInstanceTypes changeset, but not AddDimensions.
+    add_instance_types = next(c["DetailsDocument"] for c in change_set if c["ChangeType"] == "AddInstanceTypes")
+    assert add_instance_types == {"InstanceTypes": ["t1.micro"]}
+    assert not any(c["ChangeType"] == "AddDimensions" for c in change_set)
+
+    # Its pricing must remain in the rate card.
+    pricing_details = change_set[0]["DetailsDocument"]["Terms"]
+    hourly_rate_card = next(t for t in pricing_details if t["Type"] == "UsageBasedPricingTerm")["RateCards"][0][
+        "RateCard"
+    ]
+    assert {"DimensionKey": "t1.micro", "Price": "0.001"} in hourly_rate_card
 
 
 @patch("awsmp._driver.get_client")
@@ -439,7 +597,6 @@ def test_ami_product_update_instance_type_pricing_update(mock_get_details, mock_
     ap = _driver.AmiProduct(product_id="testing")
     mock_get_details.side_effect = [
         {"Dimensions": [{"Name": "c3.2xlarge"}, {"Name": "c3.4xlarge"}, {"Name": "c3.8xlarge"}]},
-        {"Description": {"Visibility": "Limited"}},
         {
             "Terms": [
                 {
@@ -468,6 +625,7 @@ def test_ami_product_update_instance_type_pricing_update(mock_get_details, mock_
                 },
             ]
         },
+        {"Description": {"Visibility": "Limited"}},
     ]
     offer_config = {
         "instance_types": [
@@ -596,7 +754,6 @@ def test_ami_product_update_instance_type_pricing_raise_on_restricted(mock_get_d
     ap = _driver.AmiProduct(product_id="testing")
     mock_get_details.side_effect = [
         {"Dimensions": []},
-        {"Description": {"Visibility": "Restricted"}},
         {
             "Terms": [
                 {
@@ -605,6 +762,7 @@ def test_ami_product_update_instance_type_pricing_raise_on_restricted(mock_get_d
                 },
             ]
         },
+        {"Description": {"Visibility": "Restricted"}},
     ]
     offer_config = {
         "instance_types": [
@@ -624,7 +782,6 @@ def test_ami_product_update_instance_type_pricing_update_exception(mock_get_deta
     ap = _driver.AmiProduct(product_id="testing")
     mock_get_details.side_effect = [
         {"Dimensions": [{"Name": "c3.2xlarge"}, {"Name": "c3.4xlarge"}, {"Name": "c3.8xlarge"}]},
-        {"Description": {"Visibility": "Limited"}},
         {
             "Terms": [
                 {
@@ -641,6 +798,7 @@ def test_ami_product_update_instance_type_pricing_update_exception(mock_get_deta
                 },
             ]
         },
+        {"Description": {"Visibility": "Limited"}},
     ]
     offer_config = {
         "instance_types": [
@@ -1033,11 +1191,11 @@ def test_build_pricing_diff(existing_prices, local_prices, expected_diffs):
 @patch("awsmp._driver.get_client")
 @patch("awsmp._driver.get_entity_details")
 def test_get_pricing_diff(mock_get_entity_details, mock_get_client, visibility, terms, changeset, expected_output):
-    mock_get_entity_details.side_effect = [{"Description": {"Visibility": visibility}}, terms]
+    mock_get_entity_details.side_effect = [{"Description": {"Visibility": visibility}}]
     mock_get_client.return_value.list_entities.return_value = {
         "EntitySummaryList": [{"EntityType": "Offer", "EntityId": "test-offer"}]
     }
-    assert _driver._get_pricing_diff("prod-id", changeset, True) == expected_output
+    assert _driver._get_pricing_diff("prod-id", changeset, True, terms["Terms"]) == expected_output
 
 
 @patch("awsmp._driver.get_client")
@@ -1045,37 +1203,35 @@ def test_get_pricing_diff(mock_get_entity_details, mock_get_client, visibility, 
 def test_get_pricing_should_raise_on_change_from_zero_to_paid(mock_get_entity_details, mock_get_client):
     mock_get_entity_details.side_effect = [
         {"Description": {"Visibility": "Public"}},
+    ]
+    existing_terms = [
         {
-            "Terms": [
+            "Type": "UsageBasedPricingTerm",
+            "RateCards": [
                 {
-                    "Type": "UsageBasedPricingTerm",
-                    "RateCards": [
-                        {
-                            "RateCard": [
-                                {"DimensionKey": "c3.4xlarge", "Price": "0.0"},
-                                {"DimensionKey": "c3.8xlarge", "Price": "0.0"},
-                            ]
-                        }
-                    ],
-                },
+                    "RateCard": [
+                        {"DimensionKey": "c3.4xlarge", "Price": "0.0"},
+                        {"DimensionKey": "c3.8xlarge", "Price": "0.0"},
+                    ]
+                }
+            ],
+        },
+        {
+            "Type": "ConfigurableUpfrontPricingTerm",
+            "CurrencyCode": "USD",
+            "RateCards": [
                 {
-                    "Type": "ConfigurableUpfrontPricingTerm",
-                    "CurrencyCode": "USD",
-                    "RateCards": [
-                        {
-                            "Selector": {"Type": "Duration", "Value": "P365D"},
-                            "Constraints": {
-                                "MultipleDimensionSelection": "Allowed",
-                                "QuantityConfiguration": "Allowed",
-                            },
-                            "RateCard": [
-                                {"DimensionKey": "c3.4xlarge", "Price": "0.0"},
-                                {"DimensionKey": "c3.8xlarge", "Price": "0.0"},
-                            ],
-                        }
+                    "Selector": {"Type": "Duration", "Value": "P365D"},
+                    "Constraints": {
+                        "MultipleDimensionSelection": "Allowed",
+                        "QuantityConfiguration": "Allowed",
+                    },
+                    "RateCard": [
+                        {"DimensionKey": "c3.4xlarge", "Price": "0.0"},
+                        {"DimensionKey": "c3.8xlarge", "Price": "0.0"},
                     ],
-                },
-            ]
+                }
+            ],
         },
     ]
     mock_get_client.return_value.list_entities.return_value = {
@@ -1125,7 +1281,7 @@ def test_get_pricing_should_raise_on_change_from_zero_to_paid(mock_get_entity_de
         ],
     )
     with pytest.raises(AmiPriceChangeError) as excInfo:
-        _driver._get_pricing_diff("prod-id", changeset, False)
+        _driver._get_pricing_diff("prod-id", changeset, False, existing_terms)
     assert "Free product was attempted to be converted to paid product." in excInfo.value.args[0]
 
 
@@ -1187,7 +1343,6 @@ def test_get_pricing_should_raise_on_change_in_pricing_model(
 
     mock_get_entity_details.side_effect = [
         {"Description": {"Visibility": "Public"}},
-        {"Terms": _build_pricing_terms(existing_terms)},
     ]
     mock_get_client.return_value.list_entities.return_value = {
         "EntitySummaryList": [{"EntityType": "Offer", "EntityId": "test-offer"}]
@@ -1203,7 +1358,7 @@ def test_get_pricing_should_raise_on_change_in_pricing_model(
         ],
     )
     with pytest.raises(AmiPricingModelChangeError) as excInfo:
-        _driver._get_pricing_diff("prod-id", changeset, True)
+        _driver._get_pricing_diff("prod-id", changeset, True, _build_pricing_terms(existing_terms))
 
     assert "Listing is published. Contact AWS Marketplace to change the pricing type." in excInfo.value.args[0]
 
@@ -1471,7 +1626,7 @@ def test_ami_product_update(mock_boto3, mock_get_details, mock_get_client):
         ]
     }
 
-    mock_get_details.side_effect = [{"Dimensions": []}, {"Description": {"Visibility": "Draft"}}, {"Terms": []}]
+    mock_get_details.side_effect = [{"Dimensions": []}, {"Terms": []}, {"Description": {"Visibility": "Draft"}}]
 
     mock_get_client.return_value.list_entities.return_value = {
         "EntitySummaryList": [{"EntityType": "Offer", "EntityId": "test-offer"}]
@@ -1533,7 +1688,6 @@ def test_ami_product_update_pricing_exception_by_adding_yearly_price(mock_boto3,
 
     mock_get_details.side_effect = [
         {"Dimensions": [{"Name": "a1.large"}, {"Name": "a1.xlarge"}]},
-        {"Description": {"Visibility": "Limited"}},
         {
             "Terms": [
                 {
@@ -1549,6 +1703,7 @@ def test_ami_product_update_pricing_exception_by_adding_yearly_price(mock_boto3,
                 },
             ]
         },
+        {"Description": {"Visibility": "Limited"}},
     ]
 
     mock_get_client.return_value.list_entities.return_value = {


### PR DESCRIPTION
…ross separate applies

AWS never removes a pricing dimension once created, so an instance type that has been restricted still needs its price kept in every future changeset. Two problems kept causing "Rates can't be removed from UsageBasedPricingTerm" and duplicate-restriction rejections when applying changes over multiple separate `awsmp update` runs:

- We had no memory of instance types already restricted in a previous apply, so later runs treated them as newly removed and resubmitted RestrictInstanceTypes/RestrictDimensions for them, which AWS rejects.
- We decided which instance types needed pricing preserved using the AmiProduct entity's Dimensions/Compatibility fields, but AWS actually validates rate card completeness against the Offer entity's Terms. These two entities can drift out of sync between applies, so an instance type could be silently dropped from the rate card even though the Offer still expected a price for it.

Fix both by treating the live entities as the source of truth on every apply: read already-restricted instance types from the Product so they aren't resubmitted, and read priced dimensions directly from the Offer's Terms so nothing required by AWS is ever dropped, regardless of what the Product's Dimensions currently say.

Regression tests reproduce both failure modes against the pre-fix code and pass with the fix.

## how this was tested

i used a limited listing and tested with the following path

* add a new instance type
* restrict the new instance type 
* add a different new instance type