### PR TITLE
fix: reconcile restricted instance types during listing update

### DIFF
--- a/awsmp/_driver.py
+++ b/awsmp/_driver.py
@@ -143,11 +143,26 @@ class AmiProduct:
         offer_detail = models.Offer(**offer_config)
 
         local_instance_types = {instance_type.name for instance_type in offer_detail.instance_types}
-        existing_instance_types = _get_existing_instance_types(self.product_id)
-        new_instance_types = list(local_instance_types - existing_instance_types)
-        removed_instance_types = list(existing_instance_types - local_instance_types)
+        # All dimensions the listing has ever had, regardless of current active/restricted state,
+        # plus the subset currently restricted (inactive).
+        existing_instance_types, restricted_instance_types = _get_existing_and_restricted_instance_types(
+            self.product_id
+        )
 
-        removed_instance_type_pricing = _get_removed_instance_type_pricing(self.offer_id, removed_instance_types)
+        new_instance_types = list(local_instance_types - existing_instance_types)
+        # Previously restricted types that local config wants active again. The dimension already
+        # exists, so only AddInstanceTypes is required (no AddDimensions).
+        reenabled_instance_types = list(local_instance_types & restricted_instance_types)
+        # Everything missing from local config, whether currently active or already restricted.
+        # All of these still need a price in the rate card for AWS's completeness check.
+        missing_from_local_instance_types = list(existing_instance_types - local_instance_types)
+        # Only currently-active types dropped from local config need to be newly restricted.
+        # Types already restricted must not be resubmitted to RestrictInstanceTypes/RestrictDimensions.
+        removed_instance_types = list(set(missing_from_local_instance_types) - restricted_instance_types)
+
+        removed_instance_type_pricing = _get_missing_local_instance_type_pricing(
+            self.offer_id, missing_from_local_instance_types
+        )
 
         changeset = changesets.get_ami_listing_update_instance_type_changesets(
             self.product_id,
@@ -155,13 +170,21 @@ class AmiProduct:
             offer_detail,
             new_instance_types,
             removed_instance_types,
+            reenabled_instance_types=reenabled_instance_types,
             removed_instance_type_pricing=removed_instance_type_pricing,
+        )
+
+        # Safety net: every dimension the listing will have after this update (all pre-existing
+        # dimensions plus any brand-new ones) must have a price in the rate card. AWS rejects the
+        # change set otherwise ("Rates can't be removed from UsageBasedPricingTerm").
+        _validate_pricing_terms_dimension_coverage(
+            changeset, expected_instance_types=local_instance_types | existing_instance_types
         )
 
         hourly_diff, annual_diff = _get_pricing_diff(self.product_id, changeset, price_change_allowed)
 
         if not hourly_diff and not annual_diff:
-            if not new_instance_types and not removed_instance_types:
+            if not new_instance_types and not removed_instance_types and not reenabled_instance_types:
                 # There are nothing to update
                 logger.info("There is no instance information details to update.")
                 return None, [], []
@@ -393,23 +416,24 @@ def _get_full_ratecard_info(terms: List) -> Tuple[List, List]:
     return hourly, annual
 
 
-def _get_removed_instance_type_pricing(
-    offer_id: str, removed_instance_types: List[str]
+def _get_missing_local_instance_type_pricing(
+    offer_id: str, missing_instance_types: List[str]
 ) -> Optional[List[models.InstanceTypePricing]]:
     """
-    Fetch existing pricing for instance types being removed from the listing.
+    Fetch existing pricing for dimensions absent from the local config (currently active types being
+    newly restricted, and types that were already restricted and remain absent from local config).
 
-    Removed instance types must still be included in the UpdatePricingTerms changeset because AWS validates
-    rate card completeness before applying RestrictDimensions/RestrictInstanceTypes in the same batch.
-    Omitting the removed types from the rate card causes a "Rates can't be removed from
-    UsageBasedPricingTerm" rejection.
+    Every dimension the listing has ever had must still be included in the UpdatePricingTerms rate
+    card, because AWS validates rate card completeness before applying RestrictDimensions/
+    RestrictInstanceTypes in the same batch. Omitting any of them causes a "Rates can't be removed
+    from UsageBasedPricingTerm" rejection.
 
     :param str offer_id: offer id for fetching existing terms
-    :param List[str] removed_instance_types: instance types being removed
-    :return: pricing for removed types, or None if none are being removed
+    :param List[str] missing_instance_types: instance types absent from local config
+    :return: pricing for the missing types, or None if none are missing
     :rtype: Optional[List[models.InstanceTypePricing]]
     """
-    if not removed_instance_types:
+    if not missing_instance_types:
         return None
 
     existing_terms = get_entity_details(offer_id)["Terms"]
@@ -422,8 +446,32 @@ def _get_removed_instance_type_pricing(
             price_hourly=existing_hourly_map.get(it, "0.000"),
             price_annual=existing_annual_map.get(it),
         )
-        for it in removed_instance_types
+        for it in missing_instance_types
     ]
+
+
+def _validate_pricing_terms_dimension_coverage(
+    changeset: List[ChangeSetType], expected_instance_types: set[str]
+) -> None:
+    """
+    Verify the UpdatePricingTerms rate card in the changeset covers every expected dimension.
+
+    Safety net for the invariant that every instance type dimension the listing will have after an
+    update (active, newly restricted, or still restricted) must have a price defined. Missing
+    coverage causes AWS to reject the change set with "Rates can't be removed from
+    UsageBasedPricingTerm".
+
+    :param List[ChangeSetType] changeset: changeset produced for the update
+    :param set expected_instance_types: instance types that must be priced
+    :raises MissingInstanceTypeError: if the rate card is missing pricing for any expected type
+    """
+    change = cast(dict[str, Any], changeset[0])
+    terms = change["DetailsDocument"]["Terms"]
+    hourly, _annual = _get_full_ratecard_info(terms)
+    priced_instance_types = {r["DimensionKey"] for r in hourly}
+
+    if missing := expected_instance_types - priced_instance_types:
+        raise MissingInstanceTypeError(list(missing))
 
 
 def _build_pricing_diff(existing_prices: List, local_prices: List) -> List:
@@ -477,7 +525,10 @@ def _get_pricing_diff(product_id: str, changeset: List[ChangeSetType], allow_pri
         ) != models.Offer.get_offer_type_from_offer_terms(existing_terms)
 
     if existing_listing_status == "Restricted":
-        # restricted instances do not support updating instance types
+        # This refers to the overall listing's Visibility (private/restricted-audience listing),
+        # which is a separate concept from Compatibility.RestrictedInstanceTypes (per-instance-type
+        # restriction handled in _get_instance_type_changeset_and_pricing_diff). A listing with
+        # restricted Visibility does not support updating instance types at all.
         error_message = "Restricted listings may not have instance types updated."
         raise AmiPriceChangeError(error_message)
     elif existing_listing_status != "Draft" and _has_different_pricing_model():
@@ -558,6 +609,44 @@ def _get_existing_instance_types(product_id: str):
     if "Dimensions" in entity:
         existing_instance_types = {t["Name"] for t in entity["Dimensions"]}
     return existing_instance_types
+
+
+def _get_existing_and_restricted_instance_types(product_id: str) -> Tuple[set[str], set[str]]:
+    """
+    Return all dimensions the listing has ever had, plus the subset currently restricted.
+
+    Combines both extractions into a single describe_entity call.
+
+    :param str product_id: product id
+    :return: Tuple of (all existing instance types, currently restricted instance types)
+    :rtype: Tuple[set[str], set[str]]
+    """
+    entity = get_entity_details(product_id)
+    existing_instance_types: set[str] = set()
+    if "Dimensions" in entity:
+        existing_instance_types = {t["Name"] for t in entity["Dimensions"]}
+    return existing_instance_types, _extract_restricted_instance_types(entity)
+
+
+def _extract_restricted_instance_types(entity: Dict) -> set[str]:
+    """
+    Extract the set of currently-restricted instance types from an entity/product details document.
+
+    Restricting an instance type does not remove its dimension - dimensions persist for the
+    lifetime of the listing. Compatibility.RestrictedInstanceTypes tracks which of those
+    dimensions are currently inactive.
+
+    :param Dict entity: entity details document (as returned by describe_entity)
+    :return: Set of instance type names currently restricted
+    :rtype: set[str]
+    """
+    restricted_instance_types: set[str] = set()
+    compatibility = entity.get("Compatibility")
+    if isinstance(compatibility, dict):
+        restricted = compatibility.get("RestrictedInstanceTypes")
+        if isinstance(restricted, list):
+            restricted_instance_types = set(restricted)
+    return restricted_instance_types
 
 
 def get_available_instance_types(arch: str, virt: str) -> list[str]:
@@ -698,12 +787,7 @@ def diff_entity_id_vs_local(entity_id: str, local_entity: models.EntityModel):
     """
 
     full_response = get_full_response(entity_id)
-    restricted_instance_types: set[str] = set()
-    compatibility = full_response.get("Compatibility")
-    if isinstance(compatibility, dict):
-        restricted = compatibility.get("RestrictedInstanceTypes")
-        if isinstance(restricted, list):
-            restricted_instance_types = set(restricted)
+    restricted_instance_types = _extract_restricted_instance_types(full_response)
 
     entity_from_listing = models.EntityModel(**full_response)
     diff = entity_from_listing.get_diff(local_entity, restricted_instance_types=restricted_instance_types)

--- a/awsmp/changesets.py
+++ b/awsmp/changesets.py
@@ -457,6 +457,7 @@ def get_ami_listing_update_instance_type_changesets(
     offer_detail: models.Offer,
     new_instance_types: List[str],
     removed_instance_types: List[str],
+    reenabled_instance_types: Optional[List[str]] = None,
     removed_instance_type_pricing: Optional[List[models.InstanceTypePricing]] = None,
 ) -> List[ChangeSetType]:
     """
@@ -464,13 +465,20 @@ def get_ami_listing_update_instance_type_changesets(
     :param str product_id: product id
     :param str offer_id: offer id
     :param models.Offer offer_detail: offer configuration in local confi file
-    :param List[str] new_instance_types: list of instance types to add to the listing
-    :param List[str] removed_instance_types: list of instance types to remove from the listing
+    :param List[str] new_instance_types: list of instance types to add to the listing that have never
+        existed as a dimension before. Requires both AddDimensions and AddInstanceTypes.
+    :param List[str] removed_instance_types: list of currently-active instance types to newly restrict.
+        Types that are already restricted must not be included here - resubmitting an already-restricted
+        type to RestrictInstanceTypes/RestrictDimensions is rejected by AWS.
+    :param Optional[List[str]] reenabled_instance_types: list of previously-restricted instance types
+        that local config wants active again. The dimension already exists from when the type was first
+        added, so only AddInstanceTypes is required (no AddDimensions).
     :param Optional[List[models.InstanceTypePricing]] removed_instance_type_pricing: existing pricing for
-        removed instance types. Required when removed_instance_types is non-empty. AWS requires all existing
-        dimensions to have prices in the UpdatePricingTerms rate card even when those dimensions are being
-        restricted in the same change set batch - omitting them causes a "Rates can't be removed from
-        UsageBasedPricingTerm" rejection.
+        instance types absent from local config (newly restricted or already restricted). Required
+        whenever any dimension the listing has ever had is absent from local config. AWS requires all
+        existing dimensions to have prices in the UpdatePricingTerms rate card even when those dimensions
+        are being restricted (or remain restricted) in the same change set batch - omitting them causes a
+        "Rates can't be removed from UsageBasedPricingTerm" rejection.
     :return: List of Changesets
     :rtype: List[ChangeSetType]
     """
@@ -493,6 +501,8 @@ def get_ami_listing_update_instance_type_changesets(
                 _changeset_update_ami_product_instance_type(product_id, new_instance_types),
             ]
         )
+    if reenabled_instance_types:
+        changeset_list.append(_changeset_update_ami_product_instance_type(product_id, reenabled_instance_types))
     if removed_instance_types:
         changeset_list.extend(
             [

--- a/tests/test_changesets.py
+++ b/tests/test_changesets.py
@@ -555,6 +555,57 @@ def test_get_ami_listing_update_instance_type_changesets_no_restrict_and_add_ins
     )
 
 
+def test_get_ami_listing_update_instance_type_changesets_reenable_instance_type():
+    """A previously-restricted instance type re-added to local config must be re-enabled via
+    AddInstanceTypes only (no AddDimensions - the dimension already exists), and its (possibly new)
+    price must flow into the rate card."""
+    offer_config: Dict[str, Any] = {
+        "instance_types": [
+            {"name": "c3.xlarge", "yearly": 123.44, "hourly": 0.12},
+            {"name": "c4.large", "yearly": 78.56, "hourly": 0.55},
+        ],
+        "eula_document": [{"type": "StandardEula", "version": "2025-05-05"}],
+        "refund_policy": "refund_policy",
+    }
+    offer_detail = models.Offer(**offer_config)
+    res: List[types.ChangeSetType] = changesets.get_ami_listing_update_instance_type_changesets(
+        "test-id", "test-offer_id", offer_detail, [], [], reenabled_instance_types=["c4.large"]
+    )
+    details_document = [cast(Any, item["DetailsDocument"]) for item in res[:]]
+
+    assert len(res) == 2
+    assert res[1]["ChangeType"] == "AddInstanceTypes"
+    assert details_document[1] == {"InstanceTypes": ["c4.large"]}
+    assert details_document[0]["Terms"][0]["RateCards"][0]["RateCard"][1] == {
+        "DimensionKey": "c4.large",
+        "Price": "0.55",
+    }
+
+
+def test_get_ami_listing_update_instance_type_changesets_reenable_free_instance_type():
+    """Regression: a re-enabled instance type kept at a free (0.00) price must still carry that
+    price through to the rate card rather than being silently dropped."""
+    offer_config: Dict[str, Any] = {
+        "instance_types": [
+            {"name": "c3.xlarge", "yearly": 0.00, "hourly": 0.00},
+            {"name": "c4.large", "yearly": 0.00, "hourly": 0.00},
+        ],
+        "eula_document": [{"type": "StandardEula", "version": "2025-05-05"}],
+        "refund_policy": "refund_policy",
+    }
+    offer_detail = models.Offer(**offer_config)
+    res: List[types.ChangeSetType] = changesets.get_ami_listing_update_instance_type_changesets(
+        "test-id", "test-offer_id", offer_detail, [], [], reenabled_instance_types=["c4.large"]
+    )
+    details_document = [cast(Any, item["DetailsDocument"]) for item in res[:]]
+
+    assert details_document[1] == {"InstanceTypes": ["c4.large"]}
+    assert details_document[0]["Terms"][0]["RateCards"][0]["RateCard"][1] == {
+        "DimensionKey": "c4.large",
+        "Price": "0.0",
+    }
+
+
 # ---------------------------------------------------------------------------
 # EC2 Image Builder changeset tests
 # ---------------------------------------------------------------------------

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -435,6 +435,310 @@ def test_ami_product_update_instance_type_restrict_and_add_instance_type(mock_ge
 
 @patch("awsmp._driver.get_client")
 @patch("awsmp._driver.get_entity_details")
+def test_ami_product_update_instance_type_add_and_remove_with_prior_restriction(mock_get_details, mock_get_client):
+    """Use case: add/remove instance types on a listing that has previously had instance types
+    restricted. The already-restricted type (c3.16xlarge) must not be resubmitted to
+    RestrictInstanceTypes/RestrictDimensions, but must still be priced in the rate card."""
+    ap = _driver.AmiProduct(product_id="testing")
+    mock_get_details.side_effect = [
+        {
+            "Dimensions": [
+                {"Name": "c3.2xlarge"},
+                {"Name": "c3.4xlarge"},
+                {"Name": "c3.8xlarge"},
+                {"Name": "c3.16xlarge"},
+            ],
+            "Compatibility": {"RestrictedInstanceTypes": ["c3.16xlarge"]},
+        },
+        {
+            "Terms": [
+                {
+                    "Type": "UsageBasedPricingTerm",
+                    "RateCards": [
+                        {
+                            "RateCard": [
+                                {"DimensionKey": "c3.8xlarge", "Price": "0.00"},
+                                {"DimensionKey": "c3.16xlarge", "Price": "0.00"},
+                            ]
+                        }
+                    ],
+                },
+                {
+                    "Type": "ConfigurableUpfrontPricingTerm",
+                    "RateCards": [
+                        {
+                            "RateCard": [
+                                {"DimensionKey": "c3.8xlarge", "Price": "0.00"},
+                                {"DimensionKey": "c3.16xlarge", "Price": "0.00"},
+                            ]
+                        }
+                    ],
+                },
+            ]
+        },
+        {"Description": {"Visibility": "Limited"}},
+        {
+            "Terms": [
+                {
+                    "Type": "UsageBasedPricingTerm",
+                    "RateCards": [
+                        {
+                            "RateCard": [
+                                {"DimensionKey": "c3.2xlarge", "Price": "0.00"},
+                                {"DimensionKey": "c3.4xlarge", "Price": "0.00"},
+                                {"DimensionKey": "c3.8xlarge", "Price": "0.00"},
+                                {"DimensionKey": "c3.16xlarge", "Price": "0.00"},
+                            ]
+                        }
+                    ],
+                },
+                {
+                    "Type": "ConfigurableUpfrontPricingTerm",
+                    "RateCards": [
+                        {
+                            "RateCard": [
+                                {"DimensionKey": "c3.2xlarge", "Price": "0.00"},
+                                {"DimensionKey": "c3.4xlarge", "Price": "0.00"},
+                                {"DimensionKey": "c3.8xlarge", "Price": "0.00"},
+                                {"DimensionKey": "c3.16xlarge", "Price": "0.00"},
+                            ]
+                        }
+                    ],
+                },
+            ]
+        },
+    ]
+    mock_get_client.return_value.list_entities.return_value = {
+        "EntitySummaryList": [{"EntityType": "Offer", "EntityId": "test-offer"}]
+    }
+    offer_config = {
+        "instance_types": [
+            {"name": "c3.2xlarge", "hourly": 0.00, "yearly": 0.00},
+            {"name": "c3.4xlarge", "hourly": 0.00, "yearly": 0.00},
+            {"name": "c1.medium", "hourly": 0.00, "yearly": 0.00},
+        ],
+        "refund_policy": "refund_policy",
+        "eula_document": [{"type": "StandardEula", "version": "2025-04-05"}],
+    }
+    res = ap.update_instance_types(offer_config, False)
+
+    assert mock_get_client.return_value.start_change_set.call_count == 1
+    changeset = mock_get_client.return_value.start_change_set.call_args_list[0].kwargs["ChangeSet"]
+
+    # New instance type (c1.medium): AddDimensions + AddInstanceTypes
+    assert changeset[1]["DetailsDocument"][0]["Key"] == "c1.medium"
+    assert changeset[2]["DetailsDocument"] == {"InstanceTypes": ["c1.medium"]}
+
+    # Only the newly-dropped, currently-active type is restricted. The already-restricted
+    # c3.16xlarge must NOT appear here.
+    assert changeset[3]["DetailsDocument"] == {"InstanceTypes": ["c3.8xlarge"]}
+    assert changeset[4]["DetailsDocument"] == [{"Key": "c3.8xlarge", "Types": ["Metered"]}]
+
+    # No further changesets (i.e. no re-restriction of c3.16xlarge)
+    assert len(changeset) == 5  # pricing terms, add dim, add type, restrict type, restrict dim
+
+    # But the rate card still carries a price for the already-restricted type.
+    rate_card = changeset[0]["DetailsDocument"]["Terms"][0]["RateCards"][0]["RateCard"]
+    dimension_keys = {r["DimensionKey"] for r in rate_card}
+    assert dimension_keys == {"c3.2xlarge", "c3.4xlarge", "c1.medium", "c3.8xlarge", "c3.16xlarge"}
+
+
+@patch("awsmp._driver.get_client")
+@patch("awsmp._driver.get_entity_details")
+def test_ami_product_update_instance_type_reenable_restricted_instance_type(mock_get_details, mock_get_client):
+    """Use case: re-add a previously-restricted instance type. AddInstanceTypes only is emitted
+    (the dimension already exists) and its price - here unchanged (free) - flows into the rate card."""
+    ap = _driver.AmiProduct(product_id="testing")
+    mock_get_details.side_effect = [
+        {
+            "Dimensions": [{"Name": "c3.2xlarge"}, {"Name": "c3.4xlarge"}, {"Name": "c3.8xlarge"}],
+            "Compatibility": {"RestrictedInstanceTypes": ["c3.8xlarge"]},
+        },
+        {"Description": {"Visibility": "Limited"}},
+        {
+            "Terms": [
+                {
+                    "Type": "UsageBasedPricingTerm",
+                    "RateCards": [
+                        {
+                            "RateCard": [
+                                {"DimensionKey": "c3.2xlarge", "Price": "0.00"},
+                                {"DimensionKey": "c3.4xlarge", "Price": "0.00"},
+                                {"DimensionKey": "c3.8xlarge", "Price": "0.00"},
+                            ]
+                        }
+                    ],
+                },
+                {
+                    "Type": "ConfigurableUpfrontPricingTerm",
+                    "RateCards": [
+                        {
+                            "RateCard": [
+                                {"DimensionKey": "c3.2xlarge", "Price": "0.00"},
+                                {"DimensionKey": "c3.4xlarge", "Price": "0.00"},
+                                {"DimensionKey": "c3.8xlarge", "Price": "0.00"},
+                            ]
+                        }
+                    ],
+                },
+            ]
+        },
+    ]
+    mock_get_client.return_value.list_entities.return_value = {
+        "EntitySummaryList": [{"EntityType": "Offer", "EntityId": "test-offer"}]
+    }
+    offer_config = {
+        "instance_types": [
+            {"name": "c3.2xlarge", "hourly": 0.00, "yearly": 0.00},
+            {"name": "c3.4xlarge", "hourly": 0.00, "yearly": 0.00},
+            {"name": "c3.8xlarge", "hourly": 0.00, "yearly": 0.00},
+        ],
+        "refund_policy": "refund_policy",
+        "eula_document": [{"type": "StandardEula", "version": "2025-04-05"}],
+    }
+    res = ap.update_instance_types(offer_config, False)
+
+    assert mock_get_client.return_value.start_change_set.call_count == 1
+    changeset = mock_get_client.return_value.start_change_set.call_args_list[0].kwargs["ChangeSet"]
+
+    assert changeset[1]["ChangeType"] == "AddInstanceTypes"
+    assert changeset[1]["DetailsDocument"] == {"InstanceTypes": ["c3.8xlarge"]}
+    # No AddDimensions changeset - the dimension already exists.
+    assert all(c["ChangeType"] != "AddDimensions" for c in changeset)
+
+    rate_card = changeset[0]["DetailsDocument"]["Terms"][0]["RateCards"][0]["RateCard"]
+    prices = {r["DimensionKey"]: r["Price"] for r in rate_card}
+    assert prices["c3.8xlarge"] == "0.0"
+
+
+@patch("awsmp._driver.get_client")
+@patch("awsmp._driver.get_entity_details")
+def test_ami_product_update_instance_type_reenable_restricted_instance_type_with_new_price(
+    mock_get_details, mock_get_client
+):
+    """Regression: re-enabling a previously-restricted instance type with a new (non-zero) price
+    must carry that new price into the rate card, and requires the price-change flag."""
+    ap = _driver.AmiProduct(product_id="testing")
+    mock_get_details.side_effect = [
+        {
+            "Dimensions": [{"Name": "c3.2xlarge"}, {"Name": "c3.4xlarge"}, {"Name": "c3.8xlarge"}],
+            "Compatibility": {"RestrictedInstanceTypes": ["c3.8xlarge"]},
+        },
+        {"Description": {"Visibility": "Limited"}},
+        {
+            "Terms": [
+                {
+                    "Type": "UsageBasedPricingTerm",
+                    "RateCards": [
+                        {
+                            "RateCard": [
+                                {"DimensionKey": "c3.2xlarge", "Price": "0.00"},
+                                {"DimensionKey": "c3.4xlarge", "Price": "0.00"},
+                                {"DimensionKey": "c3.8xlarge", "Price": "0.00"},
+                            ]
+                        }
+                    ],
+                },
+                {
+                    "Type": "ConfigurableUpfrontPricingTerm",
+                    "RateCards": [
+                        {
+                            "RateCard": [
+                                {"DimensionKey": "c3.2xlarge", "Price": "0.00"},
+                                {"DimensionKey": "c3.4xlarge", "Price": "0.00"},
+                                {"DimensionKey": "c3.8xlarge", "Price": "0.00"},
+                            ]
+                        }
+                    ],
+                },
+            ]
+        },
+    ]
+    mock_get_client.return_value.list_entities.return_value = {
+        "EntitySummaryList": [{"EntityType": "Offer", "EntityId": "test-offer"}]
+    }
+    offer_config = {
+        "instance_types": [
+            {"name": "c3.2xlarge", "hourly": 0.00, "yearly": 0.00},
+            {"name": "c3.4xlarge", "hourly": 0.00, "yearly": 0.00},
+            {"name": "c3.8xlarge", "hourly": 0.75, "yearly": 100.00},
+        ],
+        "refund_policy": "refund_policy",
+        "eula_document": [{"type": "StandardEula", "version": "2025-04-05"}],
+    }
+    # Without the price-change flag, the new (non-zero) price for a previously-free type must raise.
+    with pytest.raises(AmiPriceChangeError):
+        ap.update_instance_types(offer_config, False)
+
+
+@patch("awsmp._driver.get_client")
+@patch("awsmp._driver.get_entity_details")
+def test_ami_product_update_instance_type_reenable_restricted_instance_type_with_new_price_allowed(
+    mock_get_details, mock_get_client
+):
+    ap = _driver.AmiProduct(product_id="testing")
+    mock_get_details.side_effect = [
+        {
+            "Dimensions": [{"Name": "c3.2xlarge"}, {"Name": "c3.4xlarge"}, {"Name": "c3.8xlarge"}],
+            "Compatibility": {"RestrictedInstanceTypes": ["c3.8xlarge"]},
+        },
+        {"Description": {"Visibility": "Limited"}},
+        {
+            "Terms": [
+                {
+                    "Type": "UsageBasedPricingTerm",
+                    "RateCards": [
+                        {
+                            "RateCard": [
+                                {"DimensionKey": "c3.2xlarge", "Price": "0.00"},
+                                {"DimensionKey": "c3.4xlarge", "Price": "0.00"},
+                                {"DimensionKey": "c3.8xlarge", "Price": "0.00"},
+                            ]
+                        }
+                    ],
+                },
+                {
+                    "Type": "ConfigurableUpfrontPricingTerm",
+                    "RateCards": [
+                        {
+                            "RateCard": [
+                                {"DimensionKey": "c3.2xlarge", "Price": "0.00"},
+                                {"DimensionKey": "c3.4xlarge", "Price": "0.00"},
+                                {"DimensionKey": "c3.8xlarge", "Price": "0.00"},
+                            ]
+                        }
+                    ],
+                },
+            ]
+        },
+    ]
+    mock_get_client.return_value.list_entities.return_value = {
+        "EntitySummaryList": [{"EntityType": "Offer", "EntityId": "test-offer"}]
+    }
+    offer_config = {
+        "instance_types": [
+            {"name": "c3.2xlarge", "hourly": 0.00, "yearly": 0.00},
+            {"name": "c3.4xlarge", "hourly": 0.00, "yearly": 0.00},
+            {"name": "c3.8xlarge", "hourly": 0.75, "yearly": 100.00},
+        ],
+        "refund_policy": "refund_policy",
+        "eula_document": [{"type": "StandardEula", "version": "2025-04-05"}],
+    }
+    res = ap.update_instance_types(offer_config, True)
+
+    assert mock_get_client.return_value.start_change_set.call_count == 1
+    changeset = mock_get_client.return_value.start_change_set.call_args_list[0].kwargs["ChangeSet"]
+
+    assert changeset[1]["ChangeType"] == "AddInstanceTypes"
+    assert changeset[1]["DetailsDocument"] == {"InstanceTypes": ["c3.8xlarge"]}
+
+    rate_card = changeset[0]["DetailsDocument"]["Terms"][0]["RateCards"][0]["RateCard"]
+    prices = {r["DimensionKey"]: r["Price"] for r in rate_card}
+    assert prices["c3.8xlarge"] == "0.75"
+
+
+@patch("awsmp._driver.get_client")
+@patch("awsmp._driver.get_entity_details")
 def test_ami_product_update_instance_type_pricing_update(mock_get_details, mock_get_client):
     ap = _driver.AmiProduct(product_id="testing")
     mock_get_details.side_effect = [


### PR DESCRIPTION
Update previously compared local config only against Dimensions (every instance type a listing has ever had) and never checked which of those were currently restricted. This broke listings with previously-restricted instance types in two ways:

- Adding/removing instance types while other types were already restricted would resubmit the already-restricted types to RestrictInstanceTypes/RestrictDimensions, which AWS rejects.
- Re-adding a previously-restricted instance type (optionally with new pricing) was silently ignored, since it was already present as a dimension and therefore never treated as new.

Instance types are now reconciled against active vs. restricted state: brand-new types get dimensions and are added, currently-active types dropped from local config are newly restricted, previously-restricted types requested again are re-enabled without re-adding their dimension, and already-restricted types absent from local config are left alone. In all cases the pricing rate card sent to AWS still carries a price for every instance type dimension the listing has ever had, satisfying AWS's rate-card completeness requirement, including new prices for re-enabled types.

## how this was tested

* added a new instance type
* removed ^ 
* added a new instance type
* readded a removed instance type