### PR TITLE
fix: preserve pricing for already-restricted dimensions in rate card

### DIFF
--- a/awsmp/_driver.py
+++ b/awsmp/_driver.py
@@ -143,8 +143,9 @@ class AmiProduct:
         offer_detail = models.Offer(**offer_config)
 
         local_instance_types = {instance_type.name for instance_type in offer_detail.instance_types}
-        # All dimensions the listing has ever had, regardless of current active/restricted state,
-        # plus the subset currently restricted (inactive).
+        # Currently-active dimensions the listing has (from the product's Dimensions field), plus
+        # the subset currently restricted (inactive). Restricted instance types are excluded from
+        # Dimensions.
         existing_instance_types, restricted_instance_types = _get_existing_and_restricted_instance_types(
             self.product_id
         )
@@ -153,16 +154,36 @@ class AmiProduct:
         # Previously restricted types that local config wants active again. The dimension already
         # exists, so only AddInstanceTypes is required (no AddDimensions).
         reenabled_instance_types = list(local_instance_types & restricted_instance_types)
-        # Everything missing from local config, whether currently active or already restricted.
-        # All of these still need a price in the rate card for AWS's completeness check.
-        missing_from_local_instance_types = list(existing_instance_types - local_instance_types)
-        # Only currently-active types dropped from local config need to be newly restricted.
-        # Types already restricted must not be resubmitted to RestrictInstanceTypes/RestrictDimensions.
-        removed_instance_types = list(set(missing_from_local_instance_types) - restricted_instance_types)
+        # Currently-active types dropped from local config: these must be newly restricted in this
+        # batch. Types already restricted from a prior update must not be resubmitted to
+        # RestrictInstanceTypes/RestrictDimensions.
+        removed_instance_types = list((existing_instance_types - local_instance_types) - restricted_instance_types)
 
-        removed_instance_type_pricing = _get_missing_local_instance_type_pricing(
-            self.offer_id, missing_from_local_instance_types
-        )
+        # The new UpdatePricingTerms rate card must be built by *modifying* the existing offer rate
+        # card, not by rebuilding it from local config alone:
+        #   - Only dimensions being restricted/removed in THIS change set batch may be dropped.
+        #   - Dimensions already restricted from a PRIOR update must keep their existing price -
+        #     AWS rejects a rate card that silently drops rates for dimensions it still considers
+        #     part of the "existing rate card" with
+        #     "INVALID_RATE_CARD: Rates can't be removed from UsageBasedPricingTerm."
+        #   - Conversely, a dimension being restricted/removed in this same batch must NOT keep a
+        #     price - AWS rejects that with "INCOMPATIBLE_PRODUCT: Use existing, available
+        #     dimensions in the product in UsageBasedPricingTerm."
+        # local_instance_types (new/reenabled/unchanged-active) get their price from local config;
+        # every other pre-existing dimension not being removed this batch (e.g. an already-restricted
+        # type the operator isn't touching) is carried over unchanged from the existing rate card.
+        existing_terms = get_entity_details(self.offer_id)["Terms"]
+        existing_hourly, existing_annual = _get_full_ratecard_info(existing_terms)
+        preserved_rate_card_hourly = [
+            entry
+            for entry in existing_hourly
+            if entry["DimensionKey"] not in local_instance_types and entry["DimensionKey"] not in removed_instance_types
+        ]
+        preserved_rate_card_annual = [
+            entry
+            for entry in existing_annual
+            if entry["DimensionKey"] not in local_instance_types and entry["DimensionKey"] not in removed_instance_types
+        ]
 
         changeset = changesets.get_ami_listing_update_instance_type_changesets(
             self.product_id,
@@ -171,14 +192,18 @@ class AmiProduct:
             new_instance_types,
             removed_instance_types,
             reenabled_instance_types=reenabled_instance_types,
-            removed_instance_type_pricing=removed_instance_type_pricing,
+            preserved_rate_card_hourly=preserved_rate_card_hourly,
+            preserved_rate_card_annual=preserved_rate_card_annual,
         )
 
-        # Safety net: every dimension the listing will have after this update (all pre-existing
-        # dimensions plus any brand-new ones) must have a price in the rate card. AWS rejects the
-        # change set otherwise ("Rates can't be removed from UsageBasedPricingTerm").
+        # Safety net: every dimension the listing will still have after this update (locally
+        # configured types, plus any still-restricted types the operator isn't touching) must have
+        # a price in the rate card. This guards against the existing offer rate card being stale or
+        # incomplete relative to the product entity, which would otherwise surface as an opaque AWS
+        # rejection ("Rates can't be removed from UsageBasedPricingTerm").
+        still_restricted_instance_types = restricted_instance_types - set(reenabled_instance_types)
         _validate_pricing_terms_dimension_coverage(
-            changeset, expected_instance_types=local_instance_types | existing_instance_types
+            changeset, expected_instance_types=local_instance_types | still_restricted_instance_types
         )
 
         hourly_diff, annual_diff = _get_pricing_diff(self.product_id, changeset, price_change_allowed)
@@ -416,50 +441,18 @@ def _get_full_ratecard_info(terms: List) -> Tuple[List, List]:
     return hourly, annual
 
 
-def _get_missing_local_instance_type_pricing(
-    offer_id: str, missing_instance_types: List[str]
-) -> Optional[List[models.InstanceTypePricing]]:
-    """
-    Fetch existing pricing for dimensions absent from the local config (currently active types being
-    newly restricted, and types that were already restricted and remain absent from local config).
-
-    Every dimension the listing has ever had must still be included in the UpdatePricingTerms rate
-    card, because AWS validates rate card completeness before applying RestrictDimensions/
-    RestrictInstanceTypes in the same batch. Omitting any of them causes a "Rates can't be removed
-    from UsageBasedPricingTerm" rejection.
-
-    :param str offer_id: offer id for fetching existing terms
-    :param List[str] missing_instance_types: instance types absent from local config
-    :return: pricing for the missing types, or None if none are missing
-    :rtype: Optional[List[models.InstanceTypePricing]]
-    """
-    if not missing_instance_types:
-        return None
-
-    existing_terms = get_entity_details(offer_id)["Terms"]
-    existing_hourly, existing_annual = _get_full_ratecard_info(existing_terms)
-    existing_hourly_map = {r["DimensionKey"]: r["Price"] for r in existing_hourly}
-    existing_annual_map = {r["DimensionKey"]: r["Price"] for r in existing_annual}
-    return [
-        models.InstanceTypePricing(
-            name=it,
-            price_hourly=existing_hourly_map.get(it, "0.000"),
-            price_annual=existing_annual_map.get(it),
-        )
-        for it in missing_instance_types
-    ]
-
-
 def _validate_pricing_terms_dimension_coverage(
     changeset: List[ChangeSetType], expected_instance_types: set[str]
 ) -> None:
     """
     Verify the UpdatePricingTerms rate card in the changeset covers every expected dimension.
 
-    Safety net for the invariant that every instance type dimension the listing will have after an
-    update (active, newly restricted, or still restricted) must have a price defined. Missing
-    coverage causes AWS to reject the change set with "Rates can't be removed from
-    UsageBasedPricingTerm".
+    Safety net for the invariant that every instance type dimension the listing will still have
+    after an update (locally configured, or still restricted and untouched this batch) must have a
+    price defined. This does not re-derive which dimensions are expected - the caller is
+    responsible for that - it only guards against the existing offer rate card being stale or
+    incomplete relative to the product entity, which would otherwise surface as an opaque AWS
+    rejection ("Rates can't be removed from UsageBasedPricingTerm").
 
     :param List[ChangeSetType] changeset: changeset produced for the update
     :param set expected_instance_types: instance types that must be priced
@@ -613,12 +606,20 @@ def _get_existing_instance_types(product_id: str):
 
 def _get_existing_and_restricted_instance_types(product_id: str) -> Tuple[set[str], set[str]]:
     """
-    Return all dimensions the listing has ever had, plus the subset currently restricted.
+    Return the active dimensions the listing currently has, plus the subset currently restricted.
 
-    Combines both extractions into a single describe_entity call.
+    Combines both extractions into a single describe_entity call. Note that the returned
+    "existing" set (from the product's Dimensions field) does NOT include currently-restricted
+    instance types.
+
+    These sets drive which instance types get RestrictInstanceTypes/RestrictDimensions calls, but
+    they must NOT be used to decide what stays priced in UpdatePricingTerms: pricing must be derived
+    from the existing offer rate card (see _get_instance_type_changeset_and_pricing_diff) since a
+    dimension already restricted from a prior update must keep its existing price, while a
+    dimension newly restricted/removed in this same batch must have its price dropped.
 
     :param str product_id: product id
-    :return: Tuple of (all existing instance types, currently restricted instance types)
+    :return: Tuple of (active existing instance types, currently restricted instance types)
     :rtype: Tuple[set[str], set[str]]
     """
     entity = get_entity_details(product_id)
@@ -632,9 +633,13 @@ def _extract_restricted_instance_types(entity: Dict) -> set[str]:
     """
     Extract the set of currently-restricted instance types from an entity/product details document.
 
-    Restricting an instance type does not remove its dimension - dimensions persist for the
-    lifetime of the listing. Compatibility.RestrictedInstanceTypes tracks which of those
-    dimensions are currently inactive.
+    Restricted instance types are excluded from the product's Dimensions list in
+    describe_entity output, even though the underlying rate card dimension (and its price) is
+    still present on the offer. AWS requires that dimension keep its price if it was restricted in
+    a prior update (removing it triggers "INVALID_RATE_CARD: Rates can't be removed from
+    UsageBasedPricingTerm"), but rejects a price for it if it is being restricted in this same
+    change-set batch ("INCOMPATIBLE_PRODUCT: Use existing, available dimensions"). Compatibility.
+    RestrictedInstanceTypes is the only place these types can be discovered from the product entity.
 
     :param Dict entity: entity details document (as returned by describe_entity)
     :return: Set of instance type names currently restricted
@@ -708,7 +713,7 @@ def offer_create(
     hourly: bool = False,
 ) -> ChangeSetReturnType:
     csvreader = csv.DictReader(pricing, fieldnames=["name", "price_hourly", "price_annual"])
-    instance_type_pricing = [models.InstanceTypePricing(**line) for line in csvreader]  # type:ignore
+    instance_type_pricing = [models.InstanceTypePricing(**line) for line in csvreader]  # type: ignore
 
     if hourly:
         for i in instance_type_pricing:

--- a/awsmp/changesets.py
+++ b/awsmp/changesets.py
@@ -59,6 +59,8 @@ def _changeset_update_pricing_terms(
     instance_type_pricing: List[models.InstanceTypePricing],
     monthly_subscription_fee: Optional[Decimal] = None,
     offer_id: Optional[str] = None,
+    preserved_rate_card_hourly: Optional[List[Dict[str, str]]] = None,
+    preserved_rate_card_annual: Optional[List[Dict[str, str]]] = None,
 ) -> ChangeSetType:
     """
     Construct the changeset for update pricing term API reqeust
@@ -66,11 +68,17 @@ def _changeset_update_pricing_terms(
     :param List[models.InstanceTypePricing] instance_type_pricing: List of InstanceTypePricing objects
     :param Optional[Decimal] monthly_subscription_fee: Monthly subscription price for monthly recurring charge
     :param Optional[str] offer_id: Offer Id to request API
+    :param Optional[List[Dict[str, str]]] preserved_rate_card_hourly: pre-existing hourly rate card
+        entries (DimensionKey/Price) to carry over unchanged - e.g. dimensions already restricted
+        from a prior update, which AWS requires to keep their price ("INVALID_RATE_CARD: Rates
+        can't be removed from UsageBasedPricingTerm").
+    :param Optional[List[Dict[str, str]]] preserved_rate_card_annual: same as above for the annual
+        rate card.
     :return: Changeset of updating pricing term
     :rtype: ChangeSetReturnType
     """
-    rate_cards_hourly: List[Dict[str, str]] = []
-    rate_cards_annual: List[Dict[str, str]] = []
+    rate_cards_hourly: List[Dict[str, str]] = list(preserved_rate_card_hourly or [])
+    rate_cards_annual: List[Dict[str, str]] = list(preserved_rate_card_annual or [])
 
     # set offer_id for combined call for private offer creation
     if not offer_id:
@@ -458,7 +466,8 @@ def get_ami_listing_update_instance_type_changesets(
     new_instance_types: List[str],
     removed_instance_types: List[str],
     reenabled_instance_types: Optional[List[str]] = None,
-    removed_instance_type_pricing: Optional[List[models.InstanceTypePricing]] = None,
+    preserved_rate_card_hourly: Optional[List[Dict[str, str]]] = None,
+    preserved_rate_card_annual: Optional[List[Dict[str, str]]] = None,
 ) -> List[ChangeSetType]:
     """
     Return list of changeset to restrict instance types with pricing term
@@ -473,25 +482,34 @@ def get_ami_listing_update_instance_type_changesets(
     :param Optional[List[str]] reenabled_instance_types: list of previously-restricted instance types
         that local config wants active again. The dimension already exists from when the type was first
         added, so only AddInstanceTypes is required (no AddDimensions).
-    :param Optional[List[models.InstanceTypePricing]] removed_instance_type_pricing: existing pricing for
-        instance types absent from local config (newly restricted or already restricted). Required
-        whenever any dimension the listing has ever had is absent from local config. AWS requires all
-        existing dimensions to have prices in the UpdatePricingTerms rate card even when those dimensions
-        are being restricted (or remain restricted) in the same change set batch - omitting them causes a
-        "Rates can't be removed from UsageBasedPricingTerm" rejection.
+    :param Optional[List[Dict[str, str]]] preserved_rate_card_hourly: existing hourly rate card entries
+        (DimensionKey/Price) for dimensions not covered by offer_detail.instance_types and not being
+        removed this batch - e.g. dimensions already restricted from a prior update. AWS requires these
+        to keep their price ("INVALID_RATE_CARD: Rates can't be removed from UsageBasedPricingTerm").
+    :param Optional[List[Dict[str, str]]] preserved_rate_card_annual: same as above for the annual
+        rate card.
     :return: List of Changesets
     :rtype: List[ChangeSetType]
     """
 
+    # The UpdatePricingTerms rate card is built by modifying the existing offer rate card rather
+    # than rebuilding it from local config: offer_detail.instance_types supplies prices for the
+    # instance types that will be locally active after this update (new/reenabled/unchanged), while
+    # preserved_rate_card_hourly/annual carries over every other pre-existing dimension the caller
+    # has determined should be left untouched (e.g. already-restricted types). Dimensions being
+    # restricted/removed in this same batch (removed_instance_types) must be excluded from both -
+    # AWS rejects a rate card that still prices a dimension being restricted this batch with
+    # "INCOMPATIBLE_PRODUCT: Use existing, available dimensions in the product in
+    # UsageBasedPricingTerm".
     all_instance_type_pricing = list(offer_detail.instance_types)
-    if removed_instance_type_pricing:
-        all_instance_type_pricing.extend(removed_instance_type_pricing)
 
     changeset_list = [
         _changeset_update_pricing_terms(
             all_instance_type_pricing,
             monthly_subscription_fee=offer_detail.monthly_subscription_fee,
             offer_id=offer_id,
+            preserved_rate_card_hourly=preserved_rate_card_hourly,
+            preserved_rate_card_annual=preserved_rate_card_annual,
         )
     ]
     if new_instance_types:

--- a/awsmp/models.py
+++ b/awsmp/models.py
@@ -228,7 +228,7 @@ class Offer(BaseModel):
 
 
 class Region(BaseModel):
-    commercial_regions: conlist(str)  # type:ignore
+    commercial_regions: conlist(str)  # type: ignore
     future_region_support: bool
 
     @field_validator("commercial_regions")
@@ -268,14 +268,14 @@ class Description(BaseModel):
     short_description: str = Field(max_length=1000)
     long_description: str = Field(max_length=5000)
     logourl: HttpUrl
-    highlights: conlist(str, min_length=1, max_length=3)  # type:ignore
-    categories: conlist(str, min_length=1, max_length=3)  # type:ignore
-    search_keywords: conlist(str, min_length=1)  # type:ignore
+    highlights: conlist(str, min_length=1, max_length=3)  # type: ignore
+    categories: conlist(str, min_length=1, max_length=3)  # type: ignore
+    search_keywords: conlist(str, min_length=1)  # type: ignore
     support_description: str = Field(max_length=2000)
     support_resources: Optional[List[str]] = Field(default=[])
     sku: Optional[str] = Field(max_length=100, default=None)
-    video_urls: Optional[conlist(HttpUrl, min_length=0, max_length=1)] = Field(default=[])  # type:ignore
-    additional_resources: Optional[conlist(Dict[str, HttpUrl], min_length=0, max_length=3)] = Field(  # type:ignore
+    video_urls: Optional[conlist(HttpUrl, min_length=0, max_length=1)] = Field(default=[])  # type: ignore
+    additional_resources: Optional[conlist(Dict[str, HttpUrl], min_length=0, max_length=3)] = Field(  # type: ignore
         default=[]
     )
 
@@ -330,13 +330,13 @@ class AmiVersion(BaseModel):
     ami_id: str = Field(max_length=21)
     access_role_arn: str = Field(max_length=150)
     os_user_name: str = Field(max_length=100)
-    os_system_name: constr(to_upper=True)  # type:ignore
+    os_system_name: constr(to_upper=True)  # type: ignore
     os_system_version: str = Field(max_length=100)
     scanning_port: int = Field(gt=1, le=65535)
     usage_instructions: str = Field(max_length=2000)
     recommended_instance_type: str = Field(max_length=27)
     ip_protocol: Literal["tcp", "udp"]
-    ip_ranges: conlist(str, min_length=0, max_length=5)  # type:ignore
+    ip_ranges: conlist(str, min_length=0, max_length=5)  # type: ignore
     to_port: int = Field(gt=1, le=65535)
     from_port: int = Field(gt=1, le=65535)
 
@@ -403,7 +403,7 @@ class IBVersion(BaseModel):
     version_title: str = Field(min_length=1)
     release_notes: str = Field(max_length=30000)
     access_role_arn: str = Field(max_length=150)
-    delivery_options: conlist(IBDeliveryOption, min_length=1)  # type:ignore
+    delivery_options: conlist(IBDeliveryOption, min_length=1)  # type: ignore
 
     @field_validator("access_role_arn")
     def ib_access_role_arn_validator(cls, value):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -356,6 +356,30 @@ def test_public_offer_product_update_details(mock_get_client, mock_get_details, 
 
     mock_get_details.side_effect = [
         {"Dimensions": [{"Name": "a1.large"}]},
+        {
+            "Terms": [
+                {
+                    "Type": "UsageBasedPricingTerm",
+                    "RateCards": [
+                        {
+                            "RateCard": [
+                                {"DimensionKey": "a1.large", "Price": "0.004"},
+                            ]
+                        }
+                    ],
+                },
+                {
+                    "Type": "ConfigurableUpfrontPricingTerm",
+                    "RateCards": [
+                        {
+                            "RateCard": [
+                                {"DimensionKey": "a1.large", "Price": "24.528"},
+                            ]
+                        }
+                    ],
+                },
+            ]
+        },
         {"Description": {"Visibility": "Limited"}},
         {
             "Terms": [
@@ -414,6 +438,32 @@ def test_public_offer_product_update_details_pricing_change(mock_get_client, moc
 
     mock_get_details.side_effect = [
         {"Dimensions": [{"Name": "a1.large"}, {"Name": "a1.xlarge"}]},
+        {
+            "Terms": [
+                {
+                    "Type": "UsageBasedPricingTerm",
+                    "RateCards": [
+                        {
+                            "RateCard": [
+                                {"DimensionKey": "a1.large", "Price": "0.004"},
+                                {"DimensionKey": "a1.xlarge", "Price": "0.007"},
+                            ]
+                        }
+                    ],
+                },
+                {
+                    "Type": "ConfigurableUpfrontPricingTerm",
+                    "RateCards": [
+                        {
+                            "RateCard": [
+                                {"DimensionKey": "a1.large", "Price": "24.528"},
+                                {"DimensionKey": "a1.xlarge", "Price": "50.056"},
+                            ]
+                        }
+                    ],
+                },
+            ]
+        },
         {"Description": {"Visibility": "Limited"}},
         {
             "Terms": [
@@ -474,6 +524,21 @@ def test_public_offer_product_update_details_raise_exception(mock_get_client, mo
 
     mock_get_details.side_effect = [
         {"Dimensions": [{"Name": "a1.large"}, {"Name": "a1.xlarge"}]},
+        {
+            "Terms": [
+                {
+                    "Type": "UsageBasedPricingTerm",
+                    "RateCards": [
+                        {
+                            "RateCard": [
+                                {"DimensionKey": "a1.large", "Price": "0.004"},
+                                {"DimensionKey": "a1.xlarge", "Price": "0.007"},
+                            ]
+                        }
+                    ],
+                },
+            ]
+        },
         {"Description": {"Visibility": "Restricted"}},
         {
             "Terms": [
@@ -604,7 +669,9 @@ def test_public_offer_product_update_details_restrict_instance_types(mock_get_cl
         "RateCards"
     ][0]["RateCard"]
     rate_card_keys = {r["DimensionKey"] for r in rate_card}
-    assert "t1.micro" in rate_card_keys
+    # t1.micro is being restricted in this same batch, so it must be excluded from the new rate
+    # card entirely - AWS rejects resubmitting a price for it as an unavailable dimension.
+    assert "t1.micro" not in rate_card_keys
 
 
 @patch("awsmp._driver.changesets.models.boto3")
@@ -622,6 +689,32 @@ def test_public_offer_product_update_details_pricing_change_allowed(
 
     mock_get_details.side_effect = [
         {"Dimensions": [{"Name": "a1.large"}, {"Name": "a1.xlarge"}]},
+        {
+            "Terms": [
+                {
+                    "Type": "UsageBasedPricingTerm",
+                    "RateCards": [
+                        {
+                            "RateCard": [
+                                {"DimensionKey": "a1.large", "Price": "0.004"},
+                                {"DimensionKey": "a1.xlarge", "Price": "0.007"},
+                            ]
+                        }
+                    ],
+                },
+                {
+                    "Type": "ConfigurableUpfrontPricingTerm",
+                    "RateCards": [
+                        {
+                            "RateCard": [
+                                {"DimensionKey": "a1.large", "Price": "24.528"},
+                                {"DimensionKey": "a1.xlarge", "Price": "50.056"},
+                            ]
+                        }
+                    ],
+                },
+            ]
+        },
         {"Description": {"Visibility": "Limited"}},
         {
             "Terms": [
@@ -691,6 +784,30 @@ def test_public_offer_product_update_instance_type(mock_get_client, mock_get_det
 
     mock_get_details.side_effect = [
         {"Dimensions": [{"Name": "a1.large"}]},
+        {
+            "Terms": [
+                {
+                    "Type": "UsageBasedPricingTerm",
+                    "RateCards": [
+                        {
+                            "RateCard": [
+                                {"DimensionKey": "a1.large", "Price": "0.004"},
+                            ]
+                        }
+                    ],
+                },
+                {
+                    "Type": "ConfigurableUpfrontPricingTerm",
+                    "RateCards": [
+                        {
+                            "RateCard": [
+                                {"DimensionKey": "a1.large", "Price": "24.528"},
+                            ]
+                        }
+                    ],
+                },
+            ]
+        },
         {"Description": {"Visibility": "Limited"}},
         {
             "Terms": [
@@ -844,6 +961,32 @@ def test_public_offer_product_update_instance_type_pricing_change(mock_get_clien
 
     mock_get_details.side_effect = [
         {"Dimensions": [{"Name": "a1.large"}, {"Name": "a1.xlarge"}]},
+        {
+            "Terms": [
+                {
+                    "Type": "UsageBasedPricingTerm",
+                    "RateCards": [
+                        {
+                            "RateCard": [
+                                {"DimensionKey": "a1.large", "Price": "0.004"},
+                                {"DimensionKey": "a1.xlarge", "Price": "0.007"},
+                            ]
+                        }
+                    ],
+                },
+                {
+                    "Type": "ConfigurableUpfrontPricingTerm",
+                    "RateCards": [
+                        {
+                            "RateCard": [
+                                {"DimensionKey": "a1.large", "Price": "24.528"},
+                                {"DimensionKey": "a1.xlarge", "Price": "30.056"},
+                            ]
+                        }
+                    ],
+                },
+            ]
+        },
         {"Description": {"Visibility": "Limited"}},
         {
             "Terms": [
@@ -913,6 +1056,32 @@ def test_public_offer_product_update_instance_type_pricing_change_not_allowed(
 
     mock_get_details.side_effect = [
         {"Dimensions": [{"Name": "a1.large"}, {"Name": "a1.xlarge"}]},
+        {
+            "Terms": [
+                {
+                    "Type": "UsageBasedPricingTerm",
+                    "RateCards": [
+                        {
+                            "RateCard": [
+                                {"DimensionKey": "a1.large", "Price": "0.004"},
+                                {"DimensionKey": "a1.xlarge", "Price": "0.007"},
+                            ]
+                        }
+                    ],
+                },
+                {
+                    "Type": "ConfigurableUpfrontPricingTerm",
+                    "RateCards": [
+                        {
+                            "RateCard": [
+                                {"DimensionKey": "a1.large", "Price": "24.528"},
+                                {"DimensionKey": "a1.xlarge", "Price": "30.056"},
+                            ]
+                        }
+                    ],
+                },
+            ]
+        },
         {"Description": {"Visibility": "Limited"}},
         {
             "Terms": [
@@ -970,6 +1139,21 @@ def test_public_offer_product_update_instance_type_pricing_change_exception(
 
     mock_get_details.side_effect = [
         {"Dimensions": [{"Name": "a1.large"}, {"Name": "a1.xlarge"}]},
+        {
+            "Terms": [
+                {
+                    "Type": "UsageBasedPricingTerm",
+                    "RateCards": [
+                        {
+                            "RateCard": [
+                                {"DimensionKey": "a1.large", "Price": "0.004"},
+                                {"DimensionKey": "a1.xlarge", "Price": "0.007"},
+                            ]
+                        }
+                    ],
+                },
+            ]
+        },
         {"Description": {"Visibility": "Restricted"}},
         {
             "Terms": [

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -186,6 +186,34 @@ def test_ami_product_update_instance_type(mock_get_details, mock_get_client):
     ap = _driver.AmiProduct(product_id="testing")
     mock_get_details.side_effect = [
         {"Dimensions": [{"Name": "c3.2xlarge"}, {"Name": "c3.4xlarge"}, {"Name": "c3.8xlarge"}]},
+        {
+            "Terms": [
+                {
+                    "Type": "UsageBasedPricingTerm",
+                    "RateCards": [
+                        {
+                            "RateCard": [
+                                {"DimensionKey": "c3.2xlarge", "Price": "0.00"},
+                                {"DimensionKey": "c3.4xlarge", "Price": "0.00"},
+                                {"DimensionKey": "c3.8xlarge", "Price": "0.00"},
+                            ]
+                        }
+                    ],
+                },
+                {
+                    "Type": "ConfigurableUpfrontPricingTerm",
+                    "RateCards": [
+                        {
+                            "RateCard": [
+                                {"DimensionKey": "c3.2xlarge", "Price": "0.00"},
+                                {"DimensionKey": "c3.4xlarge", "Price": "0.00"},
+                                {"DimensionKey": "c3.8xlarge", "Price": "0.00"},
+                            ]
+                        }
+                    ],
+                },
+            ]
+        },
         {"Description": {"Visibility": "Limited"}},
         {
             "Terms": [
@@ -336,6 +364,13 @@ def test_ami_product_update_instance_type_restrict_instance_type(mock_get_detail
         0
     ] == {"Key": "c3.8xlarge", "Types": ["Metered"]}
 
+    # The restricted dimension must NOT carry a price in the new rate card.
+    rate_card = mock_get_client.return_value.start_change_set.call_args_list[0].kwargs["ChangeSet"][0][
+        "DetailsDocument"
+    ]["Terms"][0]["RateCards"][0]["RateCard"]
+    dimension_keys = {r["DimensionKey"] for r in rate_card}
+    assert dimension_keys == {"c3.2xlarge", "c3.4xlarge"}
+
 
 @patch("awsmp._driver.get_client")
 @patch("awsmp._driver.get_entity_details")
@@ -432,13 +467,21 @@ def test_ami_product_update_instance_type_restrict_and_add_instance_type(mock_ge
         0
     ] == {"Key": "c3.8xlarge", "Types": ["Metered"]}
 
+    # The restricted dimension must NOT carry a price in the new rate card.
+    rate_card = mock_get_client.return_value.start_change_set.call_args_list[0].kwargs["ChangeSet"][0][
+        "DetailsDocument"
+    ]["Terms"][0]["RateCards"][0]["RateCard"]
+    dimension_keys = {r["DimensionKey"] for r in rate_card}
+    assert dimension_keys == {"c3.2xlarge", "c3.4xlarge", "c1.medium"}
+
 
 @patch("awsmp._driver.get_client")
 @patch("awsmp._driver.get_entity_details")
 def test_ami_product_update_instance_type_add_and_remove_with_prior_restriction(mock_get_details, mock_get_client):
     """Use case: add/remove instance types on a listing that has previously had instance types
     restricted. The already-restricted type (c3.16xlarge) must not be resubmitted to
-    RestrictInstanceTypes/RestrictDimensions, but must still be priced in the rate card."""
+    RestrictInstanceTypes/RestrictDimensions, but must keep carrying its existing price in the
+    new rate card (AWS rejects dropping it)."""
     ap = _driver.AmiProduct(product_id="testing")
     mock_get_details.side_effect = [
         {
@@ -457,6 +500,8 @@ def test_ami_product_update_instance_type_add_and_remove_with_prior_restriction(
                     "RateCards": [
                         {
                             "RateCard": [
+                                {"DimensionKey": "c3.2xlarge", "Price": "0.00"},
+                                {"DimensionKey": "c3.4xlarge", "Price": "0.00"},
                                 {"DimensionKey": "c3.8xlarge", "Price": "0.00"},
                                 {"DimensionKey": "c3.16xlarge", "Price": "0.00"},
                             ]
@@ -468,6 +513,8 @@ def test_ami_product_update_instance_type_add_and_remove_with_prior_restriction(
                     "RateCards": [
                         {
                             "RateCard": [
+                                {"DimensionKey": "c3.2xlarge", "Price": "0.00"},
+                                {"DimensionKey": "c3.4xlarge", "Price": "0.00"},
                                 {"DimensionKey": "c3.8xlarge", "Price": "0.00"},
                                 {"DimensionKey": "c3.16xlarge", "Price": "0.00"},
                             ]
@@ -537,10 +584,242 @@ def test_ami_product_update_instance_type_add_and_remove_with_prior_restriction(
     # No further changesets (i.e. no re-restriction of c3.16xlarge)
     assert len(changeset) == 5  # pricing terms, add dim, add type, restrict type, restrict dim
 
-    # But the rate card still carries a price for the already-restricted type.
+    # The rate card must exclude only the just-restricted c3.8xlarge. The already-restricted
+    # c3.16xlarge keeps its existing price untouched (AWS rejects dropping it with
+    # "INVALID_RATE_CARD: Rates can't be removed from UsageBasedPricingTerm").
     rate_card = changeset[0]["DetailsDocument"]["Terms"][0]["RateCards"][0]["RateCard"]
     dimension_keys = {r["DimensionKey"] for r in rate_card}
-    assert dimension_keys == {"c3.2xlarge", "c3.4xlarge", "c1.medium", "c3.8xlarge", "c3.16xlarge"}
+    assert dimension_keys == {"c3.2xlarge", "c3.4xlarge", "c1.medium", "c3.16xlarge"}
+
+
+@patch("awsmp._driver.get_client")
+@patch("awsmp._driver.get_entity_details")
+def test_ami_product_update_instance_type_remove_with_restricted_not_in_dimensions(mock_get_details, mock_get_client):
+    """Regression: restricted instance types are not returned in the product's Dimensions list, but
+    the underlying rate card dimension still exists on the offer and must keep its price (AWS
+    rejects dropping it with "INVALID_RATE_CARD: Rates can't be removed from
+    UsageBasedPricingTerm"). Only the dimension being newly restricted in this same batch
+    (c3.8xlarge) must be dropped from the new UpdatePricingTerms rate card - AWS rejects keeping
+    that one too ("INCOMPATIBLE_PRODUCT: Use existing, available dimensions")."""
+    ap = _driver.AmiProduct(product_id="testing")
+    mock_get_details.side_effect = [
+        # Product entity: c3.16xlarge is restricted and absent from Dimensions.
+        {
+            "Dimensions": [
+                {"Name": "c3.2xlarge"},
+                {"Name": "c3.4xlarge"},
+                {"Name": "c3.8xlarge"},
+            ],
+            "Compatibility": {"RestrictedInstanceTypes": ["c3.16xlarge"]},
+        },
+        {
+            "Terms": [
+                {
+                    "Type": "UsageBasedPricingTerm",
+                    "RateCards": [
+                        {
+                            "RateCard": [
+                                {"DimensionKey": "c3.2xlarge", "Price": "0.00"},
+                                {"DimensionKey": "c3.4xlarge", "Price": "0.00"},
+                                {"DimensionKey": "c3.8xlarge", "Price": "0.00"},
+                                {"DimensionKey": "c3.16xlarge", "Price": "0.00"},
+                            ]
+                        }
+                    ],
+                },
+                {
+                    "Type": "ConfigurableUpfrontPricingTerm",
+                    "RateCards": [
+                        {
+                            "RateCard": [
+                                {"DimensionKey": "c3.2xlarge", "Price": "0.00"},
+                                {"DimensionKey": "c3.4xlarge", "Price": "0.00"},
+                                {"DimensionKey": "c3.8xlarge", "Price": "0.00"},
+                                {"DimensionKey": "c3.16xlarge", "Price": "0.00"},
+                            ]
+                        }
+                    ],
+                },
+            ]
+        },
+        {"Description": {"Visibility": "Limited"}},
+        # Public offer terms for pricing diff.
+        {
+            "Terms": [
+                {
+                    "Type": "UsageBasedPricingTerm",
+                    "RateCards": [
+                        {
+                            "RateCard": [
+                                {"DimensionKey": "c3.2xlarge", "Price": "0.00"},
+                                {"DimensionKey": "c3.4xlarge", "Price": "0.00"},
+                                {"DimensionKey": "c3.8xlarge", "Price": "0.00"},
+                                {"DimensionKey": "c3.16xlarge", "Price": "0.00"},
+                            ]
+                        }
+                    ],
+                },
+                {
+                    "Type": "ConfigurableUpfrontPricingTerm",
+                    "RateCards": [
+                        {
+                            "RateCard": [
+                                {"DimensionKey": "c3.2xlarge", "Price": "0.00"},
+                                {"DimensionKey": "c3.4xlarge", "Price": "0.00"},
+                                {"DimensionKey": "c3.8xlarge", "Price": "0.00"},
+                                {"DimensionKey": "c3.16xlarge", "Price": "0.00"},
+                            ]
+                        }
+                    ],
+                },
+            ]
+        },
+    ]
+    mock_get_client.return_value.list_entities.return_value = {
+        "EntitySummaryList": [{"EntityType": "Offer", "EntityId": "test-offer"}]
+    }
+    offer_config = {
+        "instance_types": [
+            {"name": "c3.2xlarge", "hourly": 0.00, "yearly": 0.00},
+            {"name": "c3.4xlarge", "hourly": 0.00, "yearly": 0.00},
+            {"name": "c1.medium", "hourly": 0.00, "yearly": 0.00},
+        ],
+        "refund_policy": "refund_policy",
+        "eula_document": [{"type": "StandardEula", "version": "2025-04-05"}],
+    }
+    res = ap.update_instance_types(offer_config, False)
+
+    assert mock_get_client.return_value.start_change_set.call_count == 1
+    changeset = mock_get_client.return_value.start_change_set.call_args_list[0].kwargs["ChangeSet"]
+
+    # New instance type (c1.medium): AddDimensions + AddInstanceTypes
+    assert changeset[1]["DetailsDocument"][0]["Key"] == "c1.medium"
+    assert changeset[2]["DetailsDocument"] == {"InstanceTypes": ["c1.medium"]}
+
+    # Only the newly-dropped, currently-active type is restricted. The already-restricted
+    # c3.16xlarge must NOT appear here.
+    assert changeset[3]["DetailsDocument"] == {"InstanceTypes": ["c3.8xlarge"]}
+    assert changeset[4]["DetailsDocument"] == [{"Key": "c3.8xlarge", "Types": ["Metered"]}]
+
+    # No further changesets (i.e. no re-restriction of c3.16xlarge)
+    assert len(changeset) == 5
+
+    # The rate card must NOT carry a price for c3.8xlarge (newly restricted this batch), but must
+    # keep the existing price for c3.16xlarge (already restricted from a prior update) untouched.
+    rate_card = changeset[0]["DetailsDocument"]["Terms"][0]["RateCards"][0]["RateCard"]
+    dimension_keys = {r["DimensionKey"] for r in rate_card}
+    assert dimension_keys == {"c3.2xlarge", "c3.4xlarge", "c1.medium", "c3.16xlarge"}
+
+
+@patch("awsmp._driver.get_client")
+@patch("awsmp._driver.get_entity_details")
+def test_ami_product_update_instance_type_plain_removal_with_prior_restriction(mock_get_details, mock_get_client):
+    """Regression for a real-world failure: plainly removing one currently-active instance type
+    (no additions) from a listing that already has a *different*, unrelated instance type
+    restricted from a prior update. AWS rejected this with "INCOMPATIBLE_PRODUCT: Use existing,
+    available dimensions in the product in UsageBasedPricingTerm" when the dimension being newly
+    restricted in this same batch (c6i.xlarge) kept a price. The already-restricted dimension
+    (c6i.large) must keep its existing price - dropping it triggers a separate AWS rejection,
+    "INVALID_RATE_CARD: Rates can't be removed from UsageBasedPricingTerm"."""
+    ap = _driver.AmiProduct(product_id="testing")
+    mock_get_details.side_effect = [
+        # Product entity: c6i.large is already restricted from a prior update and absent from
+        # Dimensions. c5.large and c6i.xlarge are currently active.
+        {
+            "Dimensions": [
+                {"Name": "c5.large"},
+                {"Name": "c6i.xlarge"},
+            ],
+            "Compatibility": {"RestrictedInstanceTypes": ["c6i.large"]},
+        },
+        {
+            "Terms": [
+                {
+                    "Type": "UsageBasedPricingTerm",
+                    "RateCards": [
+                        {
+                            "RateCard": [
+                                {"DimensionKey": "c5.large", "Price": "0.10"},
+                                {"DimensionKey": "c6i.xlarge", "Price": "0.50"},
+                                {"DimensionKey": "c6i.large", "Price": "0.20"},
+                            ]
+                        }
+                    ],
+                },
+                {
+                    "Type": "ConfigurableUpfrontPricingTerm",
+                    "RateCards": [
+                        {
+                            "RateCard": [
+                                {"DimensionKey": "c5.large", "Price": "876.00"},
+                                {"DimensionKey": "c6i.xlarge", "Price": "4380.00"},
+                                {"DimensionKey": "c6i.large", "Price": "1752.00"},
+                            ]
+                        }
+                    ],
+                },
+            ]
+        },
+        {"Description": {"Visibility": "Limited"}},
+        # Public offer terms for pricing diff.
+        {
+            "Terms": [
+                {
+                    "Type": "UsageBasedPricingTerm",
+                    "RateCards": [
+                        {
+                            "RateCard": [
+                                {"DimensionKey": "c5.large", "Price": "0.10"},
+                                {"DimensionKey": "c6i.xlarge", "Price": "0.50"},
+                                {"DimensionKey": "c6i.large", "Price": "0.20"},
+                            ]
+                        }
+                    ],
+                },
+                {
+                    "Type": "ConfigurableUpfrontPricingTerm",
+                    "RateCards": [
+                        {
+                            "RateCard": [
+                                {"DimensionKey": "c5.large", "Price": "876.00"},
+                                {"DimensionKey": "c6i.xlarge", "Price": "4380.00"},
+                                {"DimensionKey": "c6i.large", "Price": "1752.00"},
+                            ]
+                        }
+                    ],
+                },
+            ]
+        },
+    ]
+    mock_get_client.return_value.list_entities.return_value = {
+        "EntitySummaryList": [{"EntityType": "Offer", "EntityId": "test-offer"}]
+    }
+    offer_config = {
+        "instance_types": [
+            {"name": "c5.large", "hourly": 0.10, "yearly": 876.00},
+        ],
+        "refund_policy": "refund_policy",
+        "eula_document": [{"type": "StandardEula", "version": "2025-04-05"}],
+    }
+
+    # Should not raise MissingInstanceTypeError (the original regression this fix addresses).
+    res = ap.update_instance_types(offer_config, False)
+
+    assert mock_get_client.return_value.start_change_set.call_count == 1
+    changeset = mock_get_client.return_value.start_change_set.call_args_list[0].kwargs["ChangeSet"]
+
+    # No new instance types, so no AddDimensions/AddInstanceTypes changesets.
+    # c6i.xlarge (currently active, dropped from local config) is newly restricted.
+    assert changeset[1]["DetailsDocument"] == {"InstanceTypes": ["c6i.xlarge"]}
+    assert changeset[2]["DetailsDocument"] == [{"Key": "c6i.xlarge", "Types": ["Metered"]}]
+    assert len(changeset) == 3  # pricing terms, restrict type, restrict dimension
+
+    # The newly-restricted c6i.xlarge must NOT appear in the new rate card, but the
+    # already-restricted c6i.large must keep its existing price untouched, alongside the
+    # remaining local instance type c5.large.
+    rate_card = changeset[0]["DetailsDocument"]["Terms"][0]["RateCards"][0]["RateCard"]
+    dimension_keys = {r["DimensionKey"] for r in rate_card}
+    assert dimension_keys == {"c5.large", "c6i.large"}
 
 
 @patch("awsmp._driver.get_client")
@@ -553,6 +832,34 @@ def test_ami_product_update_instance_type_reenable_restricted_instance_type(mock
         {
             "Dimensions": [{"Name": "c3.2xlarge"}, {"Name": "c3.4xlarge"}, {"Name": "c3.8xlarge"}],
             "Compatibility": {"RestrictedInstanceTypes": ["c3.8xlarge"]},
+        },
+        {
+            "Terms": [
+                {
+                    "Type": "UsageBasedPricingTerm",
+                    "RateCards": [
+                        {
+                            "RateCard": [
+                                {"DimensionKey": "c3.2xlarge", "Price": "0.00"},
+                                {"DimensionKey": "c3.4xlarge", "Price": "0.00"},
+                                {"DimensionKey": "c3.8xlarge", "Price": "0.00"},
+                            ]
+                        }
+                    ],
+                },
+                {
+                    "Type": "ConfigurableUpfrontPricingTerm",
+                    "RateCards": [
+                        {
+                            "RateCard": [
+                                {"DimensionKey": "c3.2xlarge", "Price": "0.00"},
+                                {"DimensionKey": "c3.4xlarge", "Price": "0.00"},
+                                {"DimensionKey": "c3.8xlarge", "Price": "0.00"},
+                            ]
+                        }
+                    ],
+                },
+            ]
         },
         {"Description": {"Visibility": "Limited"}},
         {
@@ -624,6 +931,34 @@ def test_ami_product_update_instance_type_reenable_restricted_instance_type_with
             "Dimensions": [{"Name": "c3.2xlarge"}, {"Name": "c3.4xlarge"}, {"Name": "c3.8xlarge"}],
             "Compatibility": {"RestrictedInstanceTypes": ["c3.8xlarge"]},
         },
+        {
+            "Terms": [
+                {
+                    "Type": "UsageBasedPricingTerm",
+                    "RateCards": [
+                        {
+                            "RateCard": [
+                                {"DimensionKey": "c3.2xlarge", "Price": "0.00"},
+                                {"DimensionKey": "c3.4xlarge", "Price": "0.00"},
+                                {"DimensionKey": "c3.8xlarge", "Price": "0.00"},
+                            ]
+                        }
+                    ],
+                },
+                {
+                    "Type": "ConfigurableUpfrontPricingTerm",
+                    "RateCards": [
+                        {
+                            "RateCard": [
+                                {"DimensionKey": "c3.2xlarge", "Price": "0.00"},
+                                {"DimensionKey": "c3.4xlarge", "Price": "0.00"},
+                                {"DimensionKey": "c3.8xlarge", "Price": "0.00"},
+                            ]
+                        }
+                    ],
+                },
+            ]
+        },
         {"Description": {"Visibility": "Limited"}},
         {
             "Terms": [
@@ -681,6 +1016,34 @@ def test_ami_product_update_instance_type_reenable_restricted_instance_type_with
         {
             "Dimensions": [{"Name": "c3.2xlarge"}, {"Name": "c3.4xlarge"}, {"Name": "c3.8xlarge"}],
             "Compatibility": {"RestrictedInstanceTypes": ["c3.8xlarge"]},
+        },
+        {
+            "Terms": [
+                {
+                    "Type": "UsageBasedPricingTerm",
+                    "RateCards": [
+                        {
+                            "RateCard": [
+                                {"DimensionKey": "c3.2xlarge", "Price": "0.00"},
+                                {"DimensionKey": "c3.4xlarge", "Price": "0.00"},
+                                {"DimensionKey": "c3.8xlarge", "Price": "0.00"},
+                            ]
+                        }
+                    ],
+                },
+                {
+                    "Type": "ConfigurableUpfrontPricingTerm",
+                    "RateCards": [
+                        {
+                            "RateCard": [
+                                {"DimensionKey": "c3.2xlarge", "Price": "0.00"},
+                                {"DimensionKey": "c3.4xlarge", "Price": "0.00"},
+                                {"DimensionKey": "c3.8xlarge", "Price": "0.00"},
+                            ]
+                        }
+                    ],
+                },
+            ]
         },
         {"Description": {"Visibility": "Limited"}},
         {
@@ -743,6 +1106,34 @@ def test_ami_product_update_instance_type_pricing_update(mock_get_details, mock_
     ap = _driver.AmiProduct(product_id="testing")
     mock_get_details.side_effect = [
         {"Dimensions": [{"Name": "c3.2xlarge"}, {"Name": "c3.4xlarge"}, {"Name": "c3.8xlarge"}]},
+        {
+            "Terms": [
+                {
+                    "Type": "UsageBasedPricingTerm",
+                    "RateCards": [
+                        {
+                            "RateCard": [
+                                {"DimensionKey": "c3.2xlarge", "Price": "0.03"},
+                                {"DimensionKey": "c3.4xlarge", "Price": "0.12"},
+                                {"DimensionKey": "c3.8xlarge", "Price": "0.50"},
+                            ]
+                        }
+                    ],
+                },
+                {
+                    "Type": "ConfigurableUpfrontPricingTerm",
+                    "RateCards": [
+                        {
+                            "RateCard": [
+                                {"DimensionKey": "c3.2xlarge", "Price": "12.00"},
+                                {"DimensionKey": "c3.4xlarge", "Price": "24.00"},
+                                {"DimensionKey": "c3.8xlarge", "Price": "90.00"},
+                            ]
+                        }
+                    ],
+                },
+            ]
+        },
         {"Description": {"Visibility": "Limited"}},
         {
             "Terms": [
@@ -900,6 +1291,14 @@ def test_ami_product_update_instance_type_pricing_raise_on_restricted(mock_get_d
     ap = _driver.AmiProduct(product_id="testing")
     mock_get_details.side_effect = [
         {"Dimensions": []},
+        {
+            "Terms": [
+                {
+                    "Type": "UsageBasedPricingTerm",
+                    "RateCards": [{"RateCard": []}],
+                },
+            ]
+        },
         {"Description": {"Visibility": "Restricted"}},
         {
             "Terms": [
@@ -928,6 +1327,22 @@ def test_ami_product_update_instance_type_pricing_update_exception(mock_get_deta
     ap = _driver.AmiProduct(product_id="testing")
     mock_get_details.side_effect = [
         {"Dimensions": [{"Name": "c3.2xlarge"}, {"Name": "c3.4xlarge"}, {"Name": "c3.8xlarge"}]},
+        {
+            "Terms": [
+                {
+                    "Type": "UsageBasedPricingTerm",
+                    "RateCards": [
+                        {
+                            "RateCard": [
+                                {"DimensionKey": "c3.2xlarge", "Price": "0.03"},
+                                {"DimensionKey": "c3.4xlarge", "Price": "0.12"},
+                                {"DimensionKey": "c3.8xlarge", "Price": "0.50"},
+                            ]
+                        }
+                    ],
+                },
+            ]
+        },
         {"Description": {"Visibility": "Limited"}},
         {
             "Terms": [
@@ -1775,7 +2190,12 @@ def test_ami_product_update(mock_boto3, mock_get_details, mock_get_client):
         ]
     }
 
-    mock_get_details.side_effect = [{"Dimensions": []}, {"Description": {"Visibility": "Draft"}}, {"Terms": []}]
+    mock_get_details.side_effect = [
+        {"Dimensions": []},
+        {"Terms": []},
+        {"Description": {"Visibility": "Draft"}},
+        {"Terms": []},
+    ]
 
     mock_get_client.return_value.list_entities.return_value = {
         "EntitySummaryList": [{"EntityType": "Offer", "EntityId": "test-offer"}]
@@ -1837,6 +2257,21 @@ def test_ami_product_update_pricing_exception_by_adding_yearly_price(mock_boto3,
 
     mock_get_details.side_effect = [
         {"Dimensions": [{"Name": "a1.large"}, {"Name": "a1.xlarge"}]},
+        {
+            "Terms": [
+                {
+                    "Type": "UsageBasedPricingTerm",
+                    "RateCards": [
+                        {
+                            "RateCard": [
+                                {"DimensionKey": "a1.large", "Price": "0.004"},
+                                {"DimensionKey": "a1.xlarge", "Price": "0.007"},
+                            ]
+                        }
+                    ],
+                },
+            ]
+        },
         {"Description": {"Visibility": "Limited"}},
         {
             "Terms": [
@@ -1962,7 +2397,9 @@ def test_ami_product_update_restrict_instance_types(mock_boto3, mock_get_details
         "RateCards"
     ][0]["RateCard"]
     rate_card_keys = {r["DimensionKey"] for r in rate_card}
-    assert "c1.xlarge" in rate_card_keys
+    # c1.xlarge is being restricted in this same batch, so AWS requires it be excluded from the
+    # new rate card entirely (resubmitting its price is rejected as an unavailable dimension).
+    assert "c1.xlarge" not in rate_card_keys
 
 
 @patch("awsmp._driver.get_client")

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -442,7 +442,7 @@ class TestPricingTermModel:
                 }
             ],
         }
-        term = models.PricingTermModel(**data)  #  type: ignore
+        term = models.PricingTermModel(**data)  # type: ignore
         assert term.RateCards[0].RateCard[1].DimensionKey == "c1.xlarge"
 
     def test_pricing_term_model_annual(self):
@@ -462,7 +462,7 @@ class TestPricingTermModel:
                 }
             ],
         }
-        term = models.PricingTermModel(**data)  #  type: ignore
+        term = models.PricingTermModel(**data)  # type: ignore
         selector = cast(models.SelectorModel, term.RateCards[0].Selector)
         assert term.RateCards[0].RateCard[1].DimensionKey == "c1.xlarge" and selector.Value == "P365D"
 
@@ -484,7 +484,7 @@ class TestPricingTermModel:
             ],
         }
         with pytest.raises(ValidationError) as e:
-            models.PricingTermModel(**data)  #  type: ignore
+            models.PricingTermModel(**data)  # type: ignore
 
 
 class TestEntity:


### PR DESCRIPTION
note the line count change is high, but the actual logical changes are low. most of the changes are comments clarifying how this actually works. happy to trim this down if its overly verbose.


Live/production retesting showed the previous fix (da6872b) was still incomplete. That commit excluded EVERY restricted instance type - whether restricted in the current batch or already restricted from a prior update - from UpdatePricingTerms. Production evidence shows AWS only allows dropping a dimension's price when it is being restricted/removed in the SAME change-set batch; a dimension that was already restricted earlier and is not being touched this batch must KEEP its existing price, or AWS rejects the change set with:

    INVALID_RATE_CARD: Rates can't be removed from
    UsageBasedPricingTerm. Provide prices for all dimensions in the
    existing rate card.

Combined with the previously-established rule that a dimension being restricted THIS batch must NOT keep a price (INCOMPATIBLE_PRODUCT), the full rule is:

    | Dimension state                                  | Price? |
    |---------------------------------------------------|--------|
    | Active, unchanged                                 | Yes    |
    | Active, newly added this batch                    | Yes    |
    | Being restricted/removed THIS batch               | No     |
    | Already restricted from a PRIOR batch (untouched)  | Yes    |
    | Previously fully removed                           | No     |

# How this was tested

The fix was validated against both a test Marketplace listing and a public production listing:

- **Add/remove/add loop on a test product** – verified that instance types can be added to a listing, removed, and then new instance types added afterwards without `INCOMPATIBLE_PRODUCT` or `INVALID_RATE_CARD` errors.
- **Production listing with legacy restricted instance types** – confirmed that adding new instance types to a public listing that already had restricted types no longer drops pricing for those pre-existing restricted dimensions.

In both cases the resulting active instance-type set matched the config, and offer pricing terms retained the correct dimensions.
